### PR TITLE
feat: Add repo auto-detection and search filtering

### DIFF
--- a/src/distill_mcp/adapters/storage/sqlite_store.py
+++ b/src/distill_mcp/adapters/storage/sqlite_store.py
@@ -121,7 +121,12 @@ class SqliteStore:
         return self._row_to_memory(row)
 
     async def search(
-        self, query_text: str, query_vec: list[float], top_k: int
+        self,
+        query_text: str,
+        query_vec: list[float],
+        top_k: int,
+        *,
+        repo: str | None = None,
     ) -> list[SearchResult]:
         from distill_mcp.domain.models import SearchResult
 
@@ -134,7 +139,7 @@ class SqliteStore:
             if len(out) >= top_k:
                 break
             mem = await self.get(mid)
-            if mem:
+            if mem and (repo is None or repo in mem.repos):
                 out.append(SearchResult(memory=mem, score=score))
         return out
 

--- a/src/distill_mcp/domain/ports.py
+++ b/src/distill_mcp/domain/ports.py
@@ -14,7 +14,12 @@ class StoragePort(Protocol):
     ) -> str: ...
     async def get(self, id: str) -> Memory | None: ...
     async def search(
-        self, query_text: str, query_vec: list[float], top_k: int
+        self,
+        query_text: str,
+        query_vec: list[float],
+        top_k: int,
+        *,
+        repo: str | None = None,
     ) -> list[SearchResult]: ...
     async def delete(self, id: str) -> None: ...
     async def list_recent(

--- a/src/distill_mcp/domain/services.py
+++ b/src/distill_mcp/domain/services.py
@@ -66,9 +66,11 @@ class MemoryService:
         saved_id = await self._storage.save(memory, vec)
         return {"status": "saved", "id": saved_id, "distilled": distilled}
 
-    async def search(self, query: str, top_k: int = 5) -> list[SearchResult]:
+    async def search(
+        self, query: str, top_k: int = 5, *, repo: str | None = None
+    ) -> list[SearchResult]:
         vec = await self._embedder.embed(query)
-        return await self._storage.search(query, vec, top_k)
+        return await self._storage.search(query, vec, top_k, repo=repo)
 
     async def get(self, id: str) -> Memory | None:
         return await self._storage.get(id)

--- a/src/distill_mcp/server.py
+++ b/src/distill_mcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
 from fastmcp import FastMCP
@@ -23,28 +24,52 @@ def _svc() -> MemoryService:
     return _service
 
 
+def detect_repo() -> str | None:
+    """Detect the current git repo name from the remote URL."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip().split("/")[-1].removesuffix(".git")
+    except Exception:
+        return None
+
+
 @mcp.tool
 async def remember(
     content: str,
     type: str,
-    repos: list[str],
+    repos: list[str] | None = None,
     tags: list[str] | None = None,
 ) -> dict:
     """Distill raw input into anonymous team knowledge and store it.
 
     The raw text is processed locally by Ollama and never leaves your device.
     Only the distilled factual output is stored in the team database.
+
+    If repos is not provided, the current git repository is auto-detected.
     """
+    if repos is None:
+        detected = detect_repo()
+        repos = [detected] if detected else []
     return await _svc().remember(content, type, repos, tags)
 
 
 @mcp.tool
-async def search_memory(query: str, top_k: int = 5) -> list[dict]:
+async def search_memory(
+    query: str, top_k: int = 5, repo: str | None = None
+) -> list[dict]:
     """Search team knowledge using hybrid keyword + semantic search.
 
     Returns the most relevant memories ranked by combined relevance score.
+    Optionally filter by repo name. If not provided, returns results from all repos.
     """
-    results = await _svc().search(query, top_k)
+    results = await _svc().search(query, top_k, repo=repo)
     return [
         {
             "id": r.memory.id,

--- a/tests/test_remember_flow.py
+++ b/tests/test_remember_flow.py
@@ -54,7 +54,14 @@ class FakeStorage:
     async def delete(self, id: str) -> None:
         pass
 
-    async def search(self, query_text: str, query_vec: list[float], top_k: int) -> list:
+    async def search(
+        self,
+        query_text: str,
+        query_vec: list[float],
+        top_k: int,
+        *,
+        repo: str | None = None,
+    ) -> list:
         return []
 
     async def list_recent(self, **kw: Any) -> list:

--- a/tests/test_repo_awareness.py
+++ b/tests/test_repo_awareness.py
@@ -1,0 +1,137 @@
+"""Repo awareness — auto-detection and search filtering by repo."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from distill_mcp.domain.models import Memory, SearchResult
+from distill_mcp.domain.services import MemoryService
+from distill_mcp.server import detect_repo
+
+# -- detect_repo (sync tests, no asyncio mark) --
+
+
+def test_detect_repo_parses_ssh_url() -> None:
+    fake = type(
+        "R",
+        (),
+        {"returncode": 0, "stdout": "git@github.com:5queezer/auth-service.git\n"},
+    )
+    with patch("distill_mcp.server.subprocess.run", return_value=fake):
+        assert detect_repo() == "auth-service"
+
+
+def test_detect_repo_parses_https_url() -> None:
+    fake = type(
+        "R", (), {"returncode": 0, "stdout": "https://github.com/org/my-repo.git\n"}
+    )
+    with patch("distill_mcp.server.subprocess.run", return_value=fake):
+        assert detect_repo() == "my-repo"
+
+
+def test_detect_repo_no_suffix() -> None:
+    fake = type(
+        "R", (), {"returncode": 0, "stdout": "https://github.com/org/my-repo\n"}
+    )
+    with patch("distill_mcp.server.subprocess.run", return_value=fake):
+        assert detect_repo() == "my-repo"
+
+
+def test_detect_repo_returns_none_on_failure() -> None:
+    fake = type("R", (), {"returncode": 128, "stdout": ""})
+    with patch("distill_mcp.server.subprocess.run", return_value=fake):
+        assert detect_repo() is None
+
+
+# -- search with repo filter --
+
+
+def _mem(id: str, repos: list[str]) -> Memory:
+    return Memory(
+        id=id,
+        content=f"fact from {id}",
+        type="decision",
+        repos=repos,
+        tags=[],
+        author=None,
+        created_at=datetime.now(UTC),
+    )
+
+
+class FakeStorage:
+    """Returns pre-built search results, respects repo filter."""
+
+    def __init__(self, memories: list[Memory]) -> None:
+        self._mems = {m.id: m for m in memories}
+
+    async def search(
+        self,
+        query_text: str,
+        query_vec: list[float],
+        top_k: int,
+        *,
+        repo: str | None = None,
+    ) -> list[SearchResult]:
+        out = []
+        for m in self._mems.values():
+            if repo is None or repo in m.repos:
+                out.append(SearchResult(memory=m, score=1.0))
+            if len(out) >= top_k:
+                break
+        return out
+
+    async def check_duplicate(
+        self, vec: list[float], threshold: float = 0.95
+    ) -> str | None:
+        return None
+
+    async def save(self, memory: Any, vec: list[float], **kw: Any) -> str:
+        return memory.id
+
+    async def get(self, id: str) -> Memory | None:
+        return self._mems.get(id)
+
+    async def delete(self, id: str) -> None:
+        pass
+
+    async def list_recent(self, **kw: Any) -> list:
+        return []
+
+
+class FakeEmbedder:
+    async def embed(self, text: str) -> list[float]:
+        return [0.1] * 768
+
+
+class FakeDistiller:
+    async def distill(self, raw_text: str) -> str:
+        return raw_text
+
+
+@pytest.mark.asyncio
+async def test_search_without_repo_returns_all() -> None:
+    mems = [_mem("a", ["auth-service"]), _mem("b", ["payment-api"])]
+    svc = MemoryService(FakeStorage(mems), FakeEmbedder(), FakeDistiller())
+    results = await svc.search("fact", top_k=10)
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_search_with_repo_filters() -> None:
+    mems = [_mem("a", ["auth-service"]), _mem("b", ["payment-api"])]
+    svc = MemoryService(FakeStorage(mems), FakeEmbedder(), FakeDistiller())
+    results = await svc.search("fact", top_k=10, repo="auth-service")
+    assert len(results) == 1
+    assert results[0].memory.id == "a"
+
+
+@pytest.mark.asyncio
+async def test_search_with_nonexistent_repo_returns_empty() -> None:
+    mems = [_mem("a", ["auth-service"])]
+    svc = MemoryService(FakeStorage(mems), FakeEmbedder(), FakeDistiller())
+    results = await svc.search("fact", top_k=10, repo="no-such-repo")
+    assert results == []


### PR DESCRIPTION
## Summary

- **Auto-detect repo**: `remember` no longer requires `repos` — if omitted, the current git repo is detected from `git remote get-url origin`
- **Search by repo**: `search_memory` accepts an optional `repo` filter to scope results to a specific repository (all repos returned when omitted)
- **7 new tests**: 4 for `detect_repo` URL parsing (SSH, HTTPS, no suffix, failure), 3 for search filtering logic

## Test plan

- [x] `uv run pytest tests/ -k "not ollama"` passes (18/18)
- [x] Call `remember` without `repos` from a git repo — verify repo is auto-detected
- [x] Call `search_memory` with `repo="some-repo"` — verify only matching results returned
- [x] Call `search_memory` without `repo` — verify all results returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)