### PR TITLE
feat(search): Add noise filter, min score, and recency boost

### DIFF
--- a/src/distill_mcp/domain/services.py
+++ b/src/distill_mcp/domain/services.py
@@ -10,6 +10,32 @@ if TYPE_CHECKING:
     from distill_mcp.domain.models import Memory, SearchResult
     from distill_mcp.domain.ports import DistillerPort, EmbeddingPort, StoragePort
 
+# Noise filter: trivial inputs that should never be stored
+NOISE_PATTERNS = frozenset(
+    {
+        "hi",
+        "hello",
+        "hey",
+        "thanks",
+        "thank you",
+        "ok",
+        "okay",
+        "yes",
+        "no",
+        "sure",
+        "lgtm",
+        "\U0001f44d",
+        "\U0001f44e",
+        "\U0001f64f",
+    }
+)
+MIN_CONTENT_LENGTH = 20
+
+# Search quality thresholds
+MIN_SEARCH_SCORE = 0.35
+RECENCY_WEIGHT = 0.15
+RECENCY_HALFLIFE_DAYS = 30
+
 
 class MemoryService:
     """Core use cases: remember, search, get, update, list_recent, forget."""
@@ -27,6 +53,16 @@ class MemoryService:
         self._distiller = distiller
         self._distill_enabled = distill_enabled
 
+    @staticmethod
+    def _is_noise(text: str) -> str | None:
+        """Return rejection reason if text is noise, None otherwise."""
+        stripped = text.strip()
+        if stripped.lower() in NOISE_PATTERNS:
+            return "Input is trivial (greeting/reaction). Nothing to store."
+        if len(stripped) < MIN_CONTENT_LENGTH:
+            return f"Input too short ({len(stripped)} chars). Minimum {MIN_CONTENT_LENGTH}."
+        return None
+
     async def remember(
         self,
         raw_text: str,
@@ -35,6 +71,11 @@ class MemoryService:
         tags: list[str] | None = None,
     ) -> dict:
         from distill_mcp.domain.models import Memory
+
+        # 0. Noise filter — reject before wasting Ollama cycles
+        noise_reason = self._is_noise(raw_text)
+        if noise_reason:
+            return {"status": "rejected", "reason": noise_reason}
 
         # 1. Distill
         if self._distill_enabled:
@@ -70,7 +111,21 @@ class MemoryService:
         self, query: str, top_k: int = 5, *, repo: str | None = None
     ) -> list[SearchResult]:
         vec = await self._embedder.embed(query)
-        return await self._storage.search(query, vec, top_k, repo=repo)
+        results = await self._storage.search(query, vec, top_k, repo=repo)
+
+        # Recency boost: blend RRF score with recency signal
+        now = datetime.now(UTC)
+        for r in results:
+            age_days = (now - r.memory.created_at).days
+            recency = 1.0 / (1.0 + age_days / RECENCY_HALFLIFE_DAYS)
+            r.score = (1.0 - RECENCY_WEIGHT) * r.score + RECENCY_WEIGHT * recency
+
+        # Hard min score: drop irrelevant results
+        results = [r for r in results if r.score >= MIN_SEARCH_SCORE]
+
+        # Re-sort after recency adjustment
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results
 
     async def get(self, id: str) -> Memory | None:
         return await self._storage.get(id)

--- a/tests/test_remember_flow.py
+++ b/tests/test_remember_flow.py
@@ -83,20 +83,27 @@ def _service(
     )
 
 
+_VALID_INPUT = "We chose PostgreSQL over MySQL for pgvector support"
+
+
 async def test_happy_path_calls_distill_embed_dedup_save() -> None:
-    result = await _service().remember("raw input", "decision", ["repo"])
+    result = await _service().remember(_VALID_INPUT, "decision", ["repo"])
     assert result["status"] == "saved"
     assert call_log == ["distill", "embed", "dedup", "save"]
 
 
 async def test_no_factual_content_stops_after_distill() -> None:
-    result = await _service("NO_FACTUAL_CONTENT").remember("mood log", "context", ["r"])
+    result = await _service("NO_FACTUAL_CONTENT").remember(
+        _VALID_INPUT, "context", ["r"]
+    )
     assert result["status"] == "rejected"
     assert call_log == ["distill"]
 
 
 async def test_duplicate_stops_before_save() -> None:
-    result = await _service(dup_id="existing-123").remember("dup", "decision", ["r"])
+    result = await _service(dup_id="existing-123").remember(
+        _VALID_INPUT, "decision", ["r"]
+    )
     assert result["status"] == "duplicate"
     assert call_log == ["distill", "embed", "dedup"]
     assert "save" not in call_log

--- a/tests/test_search_quality.py
+++ b/tests/test_search_quality.py
@@ -1,0 +1,189 @@
+"""Search quality — noise filter, min score, recency boost.
+
+Tests the three quick wins that prevent low-quality storage and retrieval.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from distill_mcp.domain.models import Memory, SearchResult
+from distill_mcp.domain.services import (
+    MIN_CONTENT_LENGTH,
+    MIN_SEARCH_SCORE,
+    RECENCY_HALFLIFE_DAYS,
+    RECENCY_WEIGHT,
+    MemoryService,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# -- Fakes --
+
+
+class FakeDistiller:
+    async def distill(self, raw_text: str) -> str:
+        return f"Distilled: {raw_text}"
+
+
+class FakeEmbedder:
+    async def embed(self, text: str) -> list[float]:
+        return [0.1] * 768
+
+
+class FakeStorage:
+    def __init__(self, search_results: list[SearchResult] | None = None) -> None:
+        self._search_results = search_results or []
+
+    async def check_duplicate(
+        self, vec: list[float], threshold: float = 0.95
+    ) -> str | None:
+        return None
+
+    async def save(self, memory: Any, vec: list[float], **kw: Any) -> str:
+        return memory.id
+
+    async def get(self, id: str) -> None:
+        return None
+
+    async def delete(self, id: str) -> None:
+        pass
+
+    async def search(
+        self,
+        query_text: str,
+        query_vec: list[float],
+        top_k: int,
+        *,
+        repo: str | None = None,
+    ) -> list[SearchResult]:
+        return list(self._search_results)
+
+    async def list_recent(self, **kw: Any) -> list:
+        return []
+
+
+def _service(search_results: list[SearchResult] | None = None) -> MemoryService:
+    return MemoryService(
+        storage=FakeStorage(search_results),
+        embedder=FakeEmbedder(),
+        distiller=FakeDistiller(),
+    )
+
+
+def _memory(*, days_old: int = 0) -> Memory:
+    return Memory(
+        id="test-id",
+        content="Some fact",
+        type="decision",
+        repos=["repo"],
+        tags=[],
+        author=None,
+        created_at=datetime.now(UTC) - timedelta(days=days_old),
+    )
+
+
+# -- Noise filter tests --
+
+
+class TestNoiseFilter:
+    async def test_rejects_greeting(self) -> None:
+        result = await _service().remember("hello", "context", ["r"])
+        assert result["status"] == "rejected"
+        assert "trivial" in result["reason"]
+
+    async def test_rejects_emoji_reaction(self) -> None:
+        result = await _service().remember("\U0001f44d", "context", ["r"])
+        assert result["status"] == "rejected"
+
+    async def test_rejects_short_input(self) -> None:
+        result = await _service().remember("too short", "context", ["r"])
+        assert result["status"] == "rejected"
+        assert str(MIN_CONTENT_LENGTH) in result["reason"]
+
+    async def test_accepts_substantive_input(self) -> None:
+        result = await _service().remember(
+            "We decided to use PostgreSQL for the main database because of pgvector support.",
+            "decision",
+            ["repo"],
+        )
+        assert result["status"] == "saved"
+
+    async def test_noise_check_is_case_insensitive(self) -> None:
+        result = await _service().remember("THANKS", "context", ["r"])
+        assert result["status"] == "rejected"
+
+    async def test_noise_check_strips_whitespace(self) -> None:
+        result = await _service().remember("  ok  ", "context", ["r"])
+        assert result["status"] == "rejected"
+
+
+# -- Hard min score tests --
+
+
+class TestMinScore:
+    async def test_drops_low_score_results(self) -> None:
+        results_from_db = [
+            SearchResult(memory=_memory(), score=0.016),
+            SearchResult(memory=_memory(), score=0.02),
+        ]
+        results = await _service(results_from_db).search("fastmcp")
+        assert len(results) == 0
+
+    async def test_keeps_high_score_results(self) -> None:
+        results_from_db = [
+            SearchResult(memory=_memory(), score=0.8),
+            SearchResult(memory=_memory(), score=0.5),
+        ]
+        results = await _service(results_from_db).search("fastmcp")
+        assert len(results) == 2
+
+    async def test_mixed_scores_filters_correctly(self) -> None:
+        results_from_db = [
+            SearchResult(memory=_memory(), score=0.7),
+            SearchResult(memory=_memory(), score=0.1),
+            SearchResult(memory=_memory(), score=0.5),
+        ]
+        results = await _service(results_from_db).search("query")
+        assert len(results) == 2
+        assert all(r.score >= MIN_SEARCH_SCORE for r in results)
+
+
+# -- Recency boost tests --
+
+
+class TestRecencyBoost:
+    async def test_recent_memory_gets_boosted(self) -> None:
+        fresh = SearchResult(memory=_memory(days_old=0), score=0.5)
+        old = SearchResult(memory=_memory(days_old=90), score=0.5)
+        results = await _service([fresh, old]).search("query")
+        assert results[0].score > results[1].score
+
+    async def test_recency_doesnt_dominate(self) -> None:
+        """A much higher base score should still win over recency."""
+        old_but_relevant = SearchResult(memory=_memory(days_old=60), score=0.9)
+        fresh_but_weak = SearchResult(memory=_memory(days_old=0), score=0.4)
+        results = await _service([old_but_relevant, fresh_but_weak]).search("query")
+        assert results[0].score > results[1].score
+
+    async def test_recency_formula_correctness(self) -> None:
+        """Verify the exact recency boost for a known age."""
+        m = _memory(days_old=RECENCY_HALFLIFE_DAYS)
+        sr = SearchResult(memory=m, score=0.6)
+        results = await _service([sr]).search("query")
+        # recency = 1/(1 + 30/30) = 0.5
+        # final = 0.85 * 0.6 + 0.15 * 0.5 = 0.51 + 0.075 = 0.585
+        expected = (1 - RECENCY_WEIGHT) * 0.6 + RECENCY_WEIGHT * 0.5
+        assert abs(results[0].score - expected) < 0.001
+
+    async def test_results_sorted_by_boosted_score(self) -> None:
+        r1 = SearchResult(memory=_memory(days_old=1), score=0.5)
+        r2 = SearchResult(memory=_memory(days_old=0), score=0.5)
+        r3 = SearchResult(memory=_memory(days_old=100), score=0.5)
+        results = await _service([r1, r2, r3]).search("query")
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
## Summary
- **Noise filter** rejects greetings, emoji reactions, and inputs < 20 chars before distillation — saves Ollama cycles and prevents junk in the DB
- **Hard min score** (0.35) drops irrelevant results instead of returning them with misleading scores like 0.016
- **Recency boost** (15% weight, 30-day halflife) favors newer memories without letting freshness dominate relevance

All three changes live in `domain/services.py` (business logic, not adapter layer).

## Test plan
- [x] 13 new tests in `test_search_quality.py` covering noise filter, min score, and recency boost
- [x] Updated existing `test_remember_flow.py` inputs to pass noise filter
- [x] All 41 tests pass locally
- [x] CI green

Refs #6 #7 #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)