### PR TITLE
feat: Add self-healing knowledge gap instructions

### DIFF
--- a/src/distill_mcp/server.py
+++ b/src/distill_mcp/server.py
@@ -42,6 +42,25 @@ Trigger words that REQUIRE a `search_memory` call:
 ### Detect loops
 Before suggesting an approach, search memory first.
 If a memory says "tried X, didn't work because Y", don't suggest X again.
+
+### When search returns partial results
+If search_memory finds related context but not the exact answer:
+
+1. Tell the user what you DID find
+2. Offer TWO follow-up actions:
+   a) "I can check the git history for the reasoning"
+      → run git log --all --oneline --grep="<keyword>"
+      → distill what you find → remember it
+   b) "If you remember, tell me and I'll save it"
+      → when user answers → remember immediately
+
+Never leave a knowledge gap unfilled. Every question you ask
+is an opportunity to capture knowledge that's missing.
+
+### After answering from memory
+If you used search_memory to answer a question, and the user
+adds context or corrects you, remember the correction immediately.
+Don't wait. Don't ask. Just save.
 """,
 )
 _service: MemoryService | None = None


### PR DESCRIPTION
Add two new instruction sections to the MCP server that close the
knowledge feedback loop:

**When search returns partial results** — instead of just asking the user,
Claude now offers to actively dig into git history, distill what it finds,
and save it immediately. This fills knowledge gaps automatically.

**After answering from memory** — any correction or added context from the
user is saved instantly without asking. Every interaction becomes an
opportunity to strengthen the knowledge base.

This builds on the existing auto-store/auto-retrieve instructions from #12.