### PR TITLE
docs: add MkDocs site with Diataxis structure

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,47 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install mkdocs-material mkdocs-mermaid2-plugin
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ No author. No frustration. No names. Just a clean, reusable fact.
 
 ![Distill demo — raw thought to clean team fact](docs/demo.gif)
 
-
 ```mermaid
 flowchart LR
     A[You type freely] --> B[Ollama on your Mac]
@@ -27,20 +26,7 @@ ollama pull gemma3:4b && ollama pull nomic-embed-text
 claude mcp add distill -- python -m distill_mcp
 ```
 
-Try it:
-
-```
-You:    "Remember that we chose gRPC over REST for streaming and type safety."
-Claude: [distills locally, shows preview, waits for approval, saves]
-```
-
-## How it works
-
-The local LLM is not optional — it's the privacy component. Raw text goes to Ollama on localhost, gets distilled into an anonymous fact, and only the clean output enters the team database. Your raw text never crosses a network boundary.
-
-## Self-learning
-
-Distill ships with built-in instructions that make Claude Code use memory automatically — no prompting needed. It saves when you correct a mistake or make a decision, and searches before proposing architecture or answering "how should we..." questions.
+Then in Claude Code:
 
 ```
 You:    "No, we don't use REST here. We switched to gRPC last month."
@@ -57,86 +43,11 @@ Claude: [searches distill → finds gRPC decision]
         service since the team switched from REST last month.
 ```
 
-## Usage
-
-Once installed, Claude Code can use Distill naturally:
-
-```
-You:    "Remember that we chose gRPC over REST for inter-service
-         communication because of streaming support and type safety."
-
-Claude: I've distilled this into team knowledge:
-
-        "gRPC was chosen over REST for inter-service communication
-         due to streaming support and type safety. (2026-03)"
-
-        Should I save this to the team knowledge base?
-
-You:    "Yes"
-
-Claude: Saved as memory abc-123.
-```
-
-```
-You:    "How do our services communicate?"
-
-Claude: [searches team memory]
-        Based on your team's knowledge base, inter-service communication
-        uses gRPC, chosen for streaming support and type safety.
-```
-
-## Tools
-
-| Tool | What it does |
-|------|-------------|
-| `remember` | Distill raw input into an anonymous fact (returns preview for approval) |
-| `confirm_memory` | Confirm a pending preview and store it |
-| `search_memory` | Hybrid search — returns compact index (~30 tokens/result) |
-| `get_memories` | Fetch full content for specific IDs (batch) |
-| `get_memory` | Retrieve a single memory by ID |
-| `update_memory` | Re-distill and supersede an existing memory |
-| `list_recent` | Browse recent memories, filter by repo/tag/type |
-| `forget` | Soft-delete |
-
-## Privacy
-
-| Question | Answer |
-|----------|--------|
-| Does Anthropic see my raw input? | No. It goes to local Ollama only. |
-| Can my team read what I typed? | No. Only the distilled fact is stored. |
-| Can my manager see who wrote what? | Only if you opt in. Anonymous by default. |
-| Where is my raw text? | `~/.distill/private/` on your Mac. Delete anytime. |
-| What if distillation leaks a name? | You review every output before it's saved. |
-
-## Configuration
-
-```bash
-# These are the defaults — override as needed
-export BACKEND=local                    # local or gcp
-export DISTILL_MODEL=gemma3:4b          # Ollama model for distillation
-export EMBEDDING_MODEL=nomic-embed-text # Ollama model for embeddings
-export AUTHOR_MODE=anonymous            # anonymous | pseudonym | named
-export REVIEW_BEFORE_SAVE=true          # show distilled output for approval
-export DATA_DIR=~/.distill              # local data directory
-```
-
-## Backends
-
-**Local** (default) — SQLite + LanceDB + Ollama. Everything on your Mac. $0/month.
-
-**GCP** — Cloud SQL + pgvector + Vertex AI embeddings. Distillation still runs locally on your Mac. Team members share the same database. ~$11/month.
-
-```bash
-# Switch to GCP backend
-export BACKEND=gcp
-export DB_HOST=127.0.0.1      # via Cloud SQL Proxy
-export DB_NAME=distill
-export GCP_PROJECT=your-project
-```
+Distill saves when you correct a mistake or make a decision, and searches before proposing architecture — no prompting needed.
 
 ## What makes this different
 
-Every "memory MCP" stores your raw text in a database. Distill doesn't. The local LLM is a mandatory privacy gateway that transforms personal thoughts into impersonal team knowledge. This is the only product where contributing knowledge is psychologically safe because your exact words never leave your machine.
+Every "memory MCP" stores your raw text in a database. Distill doesn't. The local LLM is a mandatory privacy gateway that transforms personal thoughts into impersonal team knowledge.
 
 |  | Raw stays local | LLM distills | Team sync | Platform agnostic |
 |--|----------------|-------------|-----------|-------------------|
@@ -149,23 +60,15 @@ Every "memory MCP" stores your raw text in a database. Distill doesn't. The loca
 
 Based on public documentation as of March 2026.
 
-## Architecture
+## Documentation
 
-```
-src/distill_mcp/
-├── domain/           # Business logic (no external dependencies)
-│   ├── models.py     # Memory, SearchResult
-│   ├── ports.py      # StoragePort, EmbeddingPort, DistillerPort
-│   └── services.py   # remember, search, update, forget
-├── adapters/         # Implementations
-│   ├── storage/      # SQLite or PostgreSQL
-│   ├── embeddings/   # Ollama or Vertex AI
-│   └── distiller/    # Ollama (always local)
-├── server.py         # MCP tool definitions
-└── __main__.py       # Entry point
-```
-
-Clean Architecture. Dependencies point inward. `domain/` has zero knowledge of FastMCP, SQLite, or Ollama.
+- [Getting Started](https://5queezer.github.io/distill/tutorials/getting-started/) — full tutorial
+- [Installation](https://5queezer.github.io/distill/how-to/installation/) — all setup options
+- [GCP Backend](https://5queezer.github.io/distill/how-to/gcp-backend/) — team-shared database
+- [MCP Tools](https://5queezer.github.io/distill/reference/tools/) — all 8 tools
+- [Configuration](https://5queezer.github.io/distill/reference/configuration/) — environment variables
+- [Architecture](https://5queezer.github.io/distill/explanation/architecture/) — Clean Architecture design
+- [Privacy Model](https://5queezer.github.io/distill/explanation/privacy-model/) — how your data stays private
 
 ## Development
 
@@ -174,13 +77,6 @@ git clone https://github.com/5queezer/distill.git
 cd distill
 uv sync
 uv run pytest tests/ -x -v
-uv run ruff check .
-
-# Test with MCP Inspector
-fastmcp dev src/distill_mcp/server.py
-
-# Install in Claude Code
-fastmcp install claude-code src/distill_mcp/server.py
 ```
 
 ## License

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,112 @@
+---
+title: Architecture
+---
+
+# Architecture
+
+Distill follows Clean Architecture (Uncle Bob). Dependencies point inward. Business logic has no knowledge of frameworks, databases, or transport.
+
+## Layer diagram
+
+```mermaid
+graph TB
+    subgraph "MCP Transport (stdio)"
+        CC[Claude Code] -->|MCP protocol| SRV
+    end
+
+    subgraph "Server Layer"
+        SRV["server.py — 8 MCP tools"]
+        MAIN["__main__.py — wiring & startup"]
+    end
+
+    subgraph "Domain Layer (inner ring)"
+        SVC["services.py — use cases"]
+        MDL["models.py — Memory, SearchResult"]
+        PRT["ports.py — StoragePort, EmbeddingPort, DistillerPort, ScannerPort"]
+    end
+
+    subgraph "Adapters (outer ring)"
+        SQL["sqlite_store.py / postgres_store.py"]
+        EMB["ollama_embed.py / vertex_embed.py"]
+        DST["ollama_distill.py"]
+        SCN["secret_scanner.py"]
+    end
+
+    subgraph "Infrastructure"
+        OLLAMA["Ollama (localhost)"]
+        DB[(SQLite or PostgreSQL)]
+        VEC[(LanceDB or pgvector)]
+    end
+
+    MAIN -->|wires adapters| SRV
+    SRV -->|delegates to| SVC
+    SVC -->|depends on| PRT
+    SQL -.->|implements| PRT
+    EMB -.->|implements| PRT
+    DST -.->|implements| PRT
+    SCN -.->|implements| PRT
+    DST --> OLLAMA
+    EMB --> OLLAMA
+    SQL --> DB
+    SQL --> VEC
+```
+
+## Directory structure
+
+```
+src/distill_mcp/
+├── domain/              # Inner ring: pure business logic, no dependencies
+│   ├── models.py        # Memory, DistilledMemory, SearchResult (dataclasses/Pydantic)
+│   ├── ports.py         # Abstract interfaces (StoragePort, EmbeddingPort, DistillerPort)
+│   └── services.py      # Use cases: remember, search, update, forget
+│
+├── adapters/            # Outer ring: implementations of ports
+│   ├── storage/
+│   │   ├── sqlite_store.py    # StoragePort → SQLite + FTS5 + LanceDB
+│   │   └── postgres_store.py  # StoragePort → asyncpg + pgvector + tsvector
+│   ├── embeddings/
+│   │   ├── ollama_embed.py    # EmbeddingPort → local Ollama
+│   │   └── vertex_embed.py    # EmbeddingPort → Vertex AI
+│   ├── distiller/
+│   │   └── ollama_distill.py  # DistillerPort → local Ollama (always local)
+│   └── scanner/
+│       └── secret_scanner.py  # ScannerPort → gitleaks-based redaction
+│
+├── server.py            # FastMCP tool definitions — thin adapter
+├── settings.py          # pydantic-settings, env var loading
+└── __main__.py          # Entry point: wires adapters, starts FastMCP
+```
+
+## The dependency rule
+
+`server.py` depends on `domain/services.py`. Services depend on `domain/ports.py`. Adapters implement ports. **Nothing in `domain/` imports from `adapters/`.**
+
+This means you can swap SQLite for PostgreSQL, or Ollama embeddings for Vertex AI, without touching any business logic.
+
+## Backend options
+
+| Backend | Storage | Vectors | Embeddings | Distillation | Cost |
+|---------|---------|---------|------------|--------------|------|
+| `local` | SQLite + FTS5 | LanceDB | Ollama | Ollama | $0 |
+| `gcp` | Cloud SQL PostgreSQL | pgvector | Vertex AI | Ollama (local) | ~$11/mo |
+
+Distillation is **always local** regardless of backend — this is the privacy guarantee.
+
+## Key execution flows
+
+### Remember (two-phase commit)
+
+1. `remember()` sends raw text to local Ollama for distillation
+2. Scanner checks the output for leaked secrets
+3. Dedup check rejects if cosine similarity > 0.95 with existing memory
+4. Returns a preview with `pending_id` — memory is NOT stored yet
+5. User reviews and approves
+6. `confirm_memory()` saves to the storage backend
+
+### Search (hybrid with RRF)
+
+1. Query is embedded via `EmbeddingPort` (768-dim vector)
+2. Full-text search runs in parallel with vector similarity search
+3. Results are merged using Reciprocal Rank Fusion (k=60)
+4. Returns compact index (~30 tokens/result) for progressive disclosure
+5. Client fetches full content with `get_memories` for relevant results only

--- a/docs/explanation/privacy-model.md
+++ b/docs/explanation/privacy-model.md
@@ -1,0 +1,57 @@
+---
+title: Privacy Model
+---
+
+# Privacy Model
+
+## The core guarantee
+
+**Your raw text never crosses a network boundary.** The local LLM is not optional — it's the privacy component.
+
+```
+Developer input (raw text)
+        │
+        ▼
+   ┌─────────────┐
+   │ private_store│ ← JSONL, never synced, local only
+   └──────┬──────┘
+          │
+          ▼
+   ┌─────────────┐
+   │   Ollama     │ ← localhost, never crosses network
+   │  (distill)   │
+   └──────┬──────┘
+          │ distilled fact (no names, no emotion, no PII)
+          ▼
+   ┌─────────────┐
+   │   Scanner    │ ← redacts any leaked secrets
+   └──────┬──────┘
+          │
+          ▼
+   ┌─────────────┐
+   │  Team DB     │ ← team-safe knowledge
+   └─────────────┘
+```
+
+## What makes this different
+
+Every "memory MCP" stores your raw text in a database. Distill doesn't. The local LLM is a mandatory privacy gateway that transforms personal thoughts into impersonal team knowledge. Contributing knowledge is psychologically safe because your exact words never leave your machine.
+
+## FAQ
+
+| Question | Answer |
+|----------|--------|
+| Does Anthropic see my raw input? | No. It goes to local Ollama only. |
+| Can my team read what I typed? | No. Only the distilled fact is stored. |
+| Can my manager see who wrote what? | Only if you opt in (`AUTH_ENABLED=true`). Anonymous by default. |
+| Where is my raw text? | `~/.distill/private/` on your machine. Delete anytime. |
+| What if distillation leaks a name? | You review every output before it's saved. The scanner also checks for secrets. |
+
+## Author modes
+
+| Mode | Behavior |
+|------|----------|
+| `anonymous` (default) | No author attribution stored |
+| `AUTH_ENABLED=true` | Git identity (`user.email`) used for ownership and RLS enforcement |
+
+When authentication is enabled, PostgreSQL Row-Level Security policies enforce that only the author can modify or delete their memories. Anonymous users retain read-only search access.

--- a/docs/how-to/gcp-backend.md
+++ b/docs/how-to/gcp-backend.md
@@ -1,0 +1,76 @@
+---
+title: GCP Backend Setup
+---
+
+# GCP Backend Setup
+
+The GCP backend uses Cloud SQL (PostgreSQL + pgvector) for storage and Vertex AI for embeddings. Distillation still runs locally via Ollama — the privacy guarantee is preserved.
+
+## Prerequisites
+
+- A GCP project with billing enabled
+- `gcloud` CLI authenticated
+- Cloud SQL Admin API enabled
+- Vertex AI API enabled
+
+## Step 1: Create a Cloud SQL instance
+
+```bash
+gcloud sql instances create distill-db \
+  --database-version=POSTGRES_15 \
+  --tier=db-f1-micro \
+  --region=us-central1
+```
+
+## Step 2: Create the database
+
+```bash
+gcloud sql databases create distill --instance=distill-db
+```
+
+## Step 3: Set up Cloud SQL Proxy
+
+```bash
+# Download the proxy
+curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.15.2/cloud-sql-proxy.linux.amd64
+chmod +x cloud-sql-proxy
+
+# Start the proxy (runs in background)
+./cloud-sql-proxy your-project:us-central1:distill-db &
+```
+
+## Step 4: Configure environment
+
+```bash
+export BACKEND=gcp
+export DB_HOST=127.0.0.1        # via Cloud SQL Proxy
+export DB_NAME=distill
+export GCP_PROJECT=your-project
+export GCP_LOCATION=us-central1
+```
+
+## Step 5: Start Distill
+
+```bash
+python -m distill_mcp
+```
+
+The PostgreSQL store will automatically:
+
+- Create the `memories` table with pgvector extension
+- Set up full-text search indexes
+- Initialize RLS policies (if `AUTH_ENABLED=true`)
+
+## Cost
+
+Approximately **$11/month** for a `db-f1-micro` instance. Vertex AI embedding costs are negligible at typical usage volumes.
+
+## Authentication (optional)
+
+Enable git-based identity with Row-Level Security:
+
+```bash
+export AUTH_ENABLED=true
+```
+
+This uses your git identity (`user.email`) to tag memories and enforce ownership via PostgreSQL RLS policies. Anonymous users get read-only access.

--- a/docs/how-to/installation.md
+++ b/docs/how-to/installation.md
@@ -1,0 +1,63 @@
+---
+title: Installation
+---
+
+# Installation
+
+## From PyPI
+
+```bash
+pip install distill-mcp
+```
+
+For GCP backend support:
+
+```bash
+pip install distill-mcp[gcp]
+```
+
+## From source
+
+```bash
+git clone https://github.com/5queezer/distill.git
+cd distill
+uv sync
+```
+
+## Ollama models
+
+Distill requires two Ollama models:
+
+```bash
+ollama pull gemma3:4b          # distillation (raw text → anonymous fact)
+ollama pull nomic-embed-text   # embeddings (768-dim vectors for search)
+```
+
+You can override these with environment variables:
+
+```bash
+export DISTILL_MODEL=gemma3:4b          # any Ollama model
+export EMBEDDING_MODEL=nomic-embed-text # must produce 768-dim vectors
+```
+
+## Register with Claude Code
+
+```bash
+# From PyPI install
+claude mcp add distill -- python -m distill_mcp
+
+# From source
+claude mcp add distill -- uv run python -m distill_mcp
+```
+
+## Verify
+
+Run the MCP Inspector to test tools interactively:
+
+```bash
+fastmcp dev src/distill_mcp/server.py
+```
+
+## Configuration
+
+All settings are controlled via environment variables. See the [Configuration reference](../reference/configuration.md) for the full list.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+---
+title: Distill
+---
+
+# Distill
+
+**Privacy-first team memory for Claude Code.**
+
+An MCP server that gives Claude Code a shared team knowledge base. A local LLM transforms your raw input into anonymous, factual knowledge *before* anything leaves your device.
+
+No author. No frustration. No names. Just a clean, reusable fact.
+
+![Distill demo — raw thought to clean team fact](demo.gif)
+
+```mermaid
+flowchart LR
+    A[You type freely] --> B[Ollama on your Mac]
+    B --> C{Review}
+    C -- approve --> D[Team DB]
+    C -- reject --> E[Discarded]
+```
+
+## Quick start
+
+```bash
+pip install distill-mcp
+ollama pull gemma3:4b && ollama pull nomic-embed-text
+claude mcp add distill -- python -m distill_mcp
+```
+
+Then in Claude Code:
+
+```
+You:    "Remember that we chose gRPC over REST for streaming and type safety."
+Claude: [distills locally, shows preview, waits for approval, saves]
+```
+
+## Documentation
+
+This site follows the [Diataxis](https://diataxis.fr/) framework:
+
+- **[Tutorials](tutorials/getting-started.md)** — Step-by-step guides for getting started
+- **[How-To Guides](how-to/installation.md)** — Task-oriented recipes for specific goals
+- **[Reference](reference/tools.md)** — Technical details: tools, configuration, ports
+- **[Explanation](explanation/architecture.md)** — Architecture, privacy model, design decisions

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,63 @@
+---
+title: Configuration
+---
+
+# Configuration Reference
+
+All settings are controlled via environment variables (or a `.env` file). Defaults are shown below.
+
+## Core settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKEND` | `local` | Backend type: `local` or `gcp` |
+| `DATA_DIR` | `~/.team-memory` | Local data directory (SQLite, LanceDB, private store) |
+| `LOG_LEVEL` | `INFO` | Logging level |
+
+## Ollama settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama API endpoint |
+| `LLM_MODEL` | `gemma3:4b` | Model for distillation |
+| `EMBEDDING_MODEL` | `nomic-embed-text` | Model for embeddings (must produce 768-dim vectors) |
+
+## Privacy & review
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DISTILL_ENABLED` | `true` | Enable LLM distillation (disable for testing) |
+| `PREVIEW_ENABLED` | `true` | Two-phase commit: show preview before storing |
+| `PREVIEW_TTL_SECONDS` | `300` | How long a pending preview stays valid |
+| `DEFAULT_AUTHOR` | `unknown` | Default author attribution |
+| `AUTH_ENABLED` | `false` | Enable git-based identity + PostgreSQL RLS |
+
+## Search tuning
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RRF_K` | `60` | Reciprocal Rank Fusion constant |
+| `MAX_MEMORY_SIZE` | `8000` | Maximum memory content size in characters |
+| `FTS_LANGUAGE` | `simple` | Full-text search language configuration |
+
+## GCP settings
+
+Only used when `BACKEND=gcp`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | — | PostgreSQL connection string |
+| `GCP_PROJECT` | — | GCP project ID |
+| `GCP_LOCATION` | `us-central1` | GCP region for Vertex AI |
+| `CLOUD_SQL_CONNECTION` | — | Cloud SQL instance connection name |
+
+## Port interfaces
+
+Distill uses Clean Architecture ports. Each setting selects an adapter:
+
+| Port | `local` adapter | `gcp` adapter |
+|------|----------------|---------------|
+| `StoragePort` | SQLite + FTS5 + LanceDB | Cloud SQL + pgvector + tsvector |
+| `EmbeddingPort` | Ollama (`nomic-embed-text`) | Vertex AI (`text-embedding-005`) |
+| `DistillerPort` | Ollama (`gemma3:4b`) | Ollama (`gemma3:4b`) — always local |
+| `ScannerPort` | gitleaks-based secret detection | gitleaks-based secret detection |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,0 +1,91 @@
+---
+title: MCP Tools
+---
+
+# MCP Tools Reference
+
+Distill exposes 8 tools via the MCP protocol. Claude Code calls these automatically based on conversation context.
+
+## remember
+
+Distill raw input into anonymous team knowledge.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `content` | string | yes | Raw text to distill |
+| `type` | string | yes | Memory type (e.g., `decision`, `convention`, `bug`) |
+| `repos` | list[string] | no | Repository tags (auto-detected from git if omitted) |
+| `tags` | list[string] | no | Free-form tags for filtering |
+| `agent_id` | string | no | Agent identifier for multi-agent filtering |
+
+**Returns:** A preview with `pending_id` (when `PREVIEW_ENABLED=true`, the default) or the saved memory directly.
+
+**Privacy:** The raw `content` is sent to local Ollama only. The distilled output is what gets stored.
+
+## confirm_memory
+
+Confirm a pending preview and store it.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | yes | The `pending_id` from `remember` |
+| `override` | string | no | Replacement text (will be re-distilled) |
+
+## search_memory
+
+Hybrid search combining full-text (FTS5/tsvector) and vector similarity (LanceDB/pgvector), merged with Reciprocal Rank Fusion (k=60).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | yes | Search query |
+| `top_k` | int | no | Max results (default: 5, max: 100) |
+| `repo` | string | no | Filter by repository |
+| `agent_id` | string | no | Filter by agent |
+
+**Returns:** Compact index (~30 tokens/result) with `id`, `type`, `snippet`, `score`, `est_tokens`. Use `get_memories` to fetch full content for relevant results.
+
+## get_memories
+
+Fetch full memory details by IDs. Batch multiple IDs in one call.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `ids` | list[string] | yes | Memory IDs to fetch |
+
+## get_memory
+
+Retrieve a single memory by ID.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | yes | Memory ID |
+
+## update_memory
+
+Re-distill new content and supersede an existing memory. The old memory is soft-deleted.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | yes | ID of the memory to update |
+| `content` | string | yes | New raw content to distill |
+
+## list_recent
+
+List recent memories as compact index.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `repo` | string | no | Filter by repository |
+| `tag` | string | no | Filter by tag |
+| `type` | string | no | Filter by memory type |
+| `limit` | int | no | Max results (default: 20, max: 100) |
+| `agent_id` | string | no | Filter by agent |
+
+## forget
+
+Soft-delete a memory. It will no longer appear in search results.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | yes | Memory ID to delete |
+| `agent_id` | string | no | If provided, only deletes if the memory belongs to this agent |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,87 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+This tutorial walks you through installing Distill, connecting it to Claude Code, and storing your first team memory.
+
+## Prerequisites
+
+- Python 3.11+
+- [Ollama](https://ollama.ai) installed and running
+- Claude Code CLI
+
+## Step 1: Install Distill
+
+```bash
+pip install distill-mcp
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/5queezer/distill.git
+cd distill
+uv sync
+```
+
+## Step 2: Pull the required Ollama models
+
+Distill needs two models — one for distillation (turning your raw text into anonymous facts) and one for embeddings (enabling semantic search):
+
+```bash
+ollama pull gemma3:4b          # distillation
+ollama pull nomic-embed-text   # embeddings (768-dim vectors)
+```
+
+## Step 3: Register with Claude Code
+
+```bash
+claude mcp add distill -- python -m distill_mcp
+```
+
+Or if running from source:
+
+```bash
+claude mcp add distill -- uv run python -m distill_mcp
+```
+
+## Step 4: Store your first memory
+
+Open Claude Code and say:
+
+```
+You:    "Remember that we chose gRPC over REST for inter-service
+         communication because of streaming support and type safety."
+```
+
+Claude will:
+
+1. Send the raw text to your **local** Ollama for distillation
+2. Show you the distilled preview (e.g., *"gRPC was chosen over REST for inter-service communication due to streaming support and type safety."*)
+3. Wait for your approval
+4. Store the approved fact in the team database
+
+## Step 5: Search your memories
+
+```
+You:    "How do our services communicate?"
+
+Claude: [searches team memory]
+        Based on your team's knowledge base, inter-service communication
+        uses gRPC, chosen for streaming support and type safety.
+```
+
+## What you've learned
+
+- How to install Distill and its Ollama dependencies
+- How to register the MCP server with Claude Code
+- The two-phase remember flow: distill → preview → confirm
+- How search retrieves stored team knowledge
+
+## Next steps
+
+- [Installation options](../how-to/installation.md) for alternative setups
+- [GCP backend setup](../how-to/gcp-backend.md) for team-shared databases
+- [Tools reference](../reference/tools.md) for all available MCP tools

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
-site_name: distill
+site_name: Distill
 site_description: Privacy-first Team Memory MCP Server
-site_url: https://your-domain.com
+site_url: https://5queezer.github.io/distill
+repo_url: https://github.com/5queezer/distill
+repo_name: 5queezer/distill
 
 theme:
   name: material
@@ -32,7 +34,8 @@ plugins:
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.details
   - admonition
   - toc:
@@ -41,14 +44,13 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Tutorials:
-    - Overview: tutorials/index.md
     - Getting Started: tutorials/getting-started.md
   - How-To Guides:
-    - Overview: how-to/index.md
-    - Deploy to Production: how-to/deploy-to-production.md
+    - Installation: how-to/installation.md
+    - GCP Backend: how-to/gcp-backend.md
   - Reference:
-    - Overview: reference/index.md
-    - API Documentation: reference/api-documentation.md
+    - MCP Tools: reference/tools.md
+    - Configuration: reference/configuration.md
   - Explanation:
-    - Overview: explanation/index.md
-    - Architecture Overview: explanation/architecture-overview.md
+    - Architecture: explanation/architecture.md
+    - Privacy Model: explanation/privacy-model.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.5.0
+mkdocs-material>=9.0.0
+mkdocs-mermaid2-plugin>=1.0.0


### PR DESCRIPTION
## Summary
- Add a full MkDocs Material documentation site following the Diataxis framework (tutorials, how-to, reference, explanation)
- Slim down README from 189 → 82 lines, moving detailed content into the docs site
- Add GitHub Pages deployment workflow triggered on docs/mkdocs.yml changes

## Changes
- **8 new doc pages** with real project-specific content (not placeholders):
  - `tutorials/getting-started.md` — install to first memory
  - `how-to/installation.md` — all setup methods
  - `how-to/gcp-backend.md` — Cloud SQL + Vertex AI
  - `reference/tools.md` — all 8 MCP tools with parameters
  - `reference/configuration.md` — all env vars from settings.py
  - `explanation/architecture.md` — Clean Architecture with mermaid diagrams
  - `explanation/privacy-model.md` — data flow, FAQ, author modes
- **mkdocs.yml** — fixed nav, added repo link, site_url, mermaid support
- **deploy-docs.yml** — GitHub Actions workflow for GitHub Pages
- **README.md** — kept hook, quick start, comparison table; linked to docs for everything else

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Pre-commit hooks pass (YAML, secrets, whitespace)
- [ ] Enable GitHub Pages (Settings → Pages → Source: GitHub Actions) after merge