### PR TITLE
feat: GPU-agnostic embedding — NVIDIA + Apple Silicon + CPU fallback

### DIFF
--- a/docs/how-to/gpu-setup.md
+++ b/docs/how-to/gpu-setup.md
@@ -1,0 +1,151 @@
+---
+title: GPU Setup
+---
+
+# GPU Setup
+
+Distill uses Ollama for local LLM inference (distillation and embeddings). Ollama automatically detects your hardware, but you may want to tune it for your specific GPU.
+
+## Check your hardware
+
+Run the built-in hardware detection:
+
+```bash
+distill check-hardware
+```
+
+Or from source:
+
+```bash
+uv run python -m distill_mcp check-hardware
+```
+
+This reports your detected accelerator, Ollama status, and recommended configuration.
+
+## NVIDIA GPUs (CUDA)
+
+Ollama detects NVIDIA GPUs automatically when CUDA drivers are installed.
+
+### Prerequisites
+
+1. NVIDIA driver 525+ installed
+2. [Ollama](https://ollama.com/download) installed via the official installer (includes CUDA support)
+
+### Verify GPU detection
+
+```bash
+# Check driver
+nvidia-smi
+
+# Ollama should show GPU in logs
+ollama serve
+# Look for: "using CUDA"
+```
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_NUM_GPU` | auto | Number of GPU layers. `999` = all layers on GPU, `0` = CPU only |
+| `CUDA_VISIBLE_DEVICES` | all | Restrict to specific GPUs (e.g., `0` for first GPU) |
+
+```bash
+# Force all layers on GPU (maximum speed)
+export OLLAMA_NUM_GPU=999
+
+# Use only first GPU on multi-GPU systems
+export CUDA_VISIBLE_DEVICES=0
+```
+
+### Recommended models
+
+| Model | Use | VRAM required |
+|-------|-----|---------------|
+| `gemma3:4b` | Distillation | ~3 GB |
+| `nomic-embed-text` | Embeddings | ~300 MB |
+| `gemma3:1b` | Distillation (low VRAM) | ~1 GB |
+
+GPUs with 6+ GB VRAM (RTX 3060+) handle the default models comfortably.
+
+## Apple Silicon (Metal)
+
+Ollama uses Metal acceleration automatically on Apple Silicon Macs.
+
+### Prerequisites
+
+1. macOS 13+ (Ventura or later)
+2. [Ollama](https://ollama.com/download/mac) installed
+
+### Verify Metal acceleration
+
+```bash
+ollama serve
+# Look for: "using Metal"
+```
+
+No additional configuration needed. Metal uses unified memory, so available VRAM equals your system RAM.
+
+### Recommended models
+
+| Mac | RAM | Recommended distiller |
+|-----|-----|----------------------|
+| M1/M2 (8 GB) | 8 GB | `gemma3:1b` |
+| M1/M2/M3 (16 GB) | 16 GB | `gemma3:4b` (default) |
+| M3/M4 Pro/Max (32+ GB) | 32+ GB | `gemma3:4b` (default) |
+
+## CPU only
+
+Ollama works without a GPU, using CPU inference. This is slower but fully functional.
+
+### Performance expectations
+
+| Operation | GPU (RTX 3060) | Apple M2 | CPU (8-core) |
+|-----------|---------------|----------|--------------|
+| Distillation | ~2s | ~3s | ~15s |
+| Embedding | <1s | <1s | ~2s |
+
+### Tuning for CPU
+
+```bash
+# Reduce parallel requests to lower memory pressure
+export OLLAMA_NUM_PARALLEL=1
+
+# Use smaller models for faster inference
+export LLM_MODEL=gemma3:1b
+export EMBEDDING_MODEL=all-minilm
+```
+
+!!! warning "Embedding dimension compatibility"
+    If you change `EMBEDDING_MODEL`, the new model must produce the same vector dimensions as `nomic-embed-text` (768). Using `all-minilm` (384-dim) requires a fresh database — existing embeddings won't be compatible. Stick with `nomic-embed-text` unless you're starting fresh.
+
+## Ollama environment variables
+
+These are Ollama's own variables, not Distill settings. Set them before starting Ollama.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_NUM_GPU` | auto | GPU layers to offload (`999` = all, `0` = none) |
+| `OLLAMA_NUM_PARALLEL` | auto | Concurrent request slots |
+| `OLLAMA_MAX_LOADED_MODELS` | auto | Models kept in memory simultaneously |
+| `OLLAMA_HOST` | `127.0.0.1:11434` | Listen address (also used by Distill) |
+| `CUDA_VISIBLE_DEVICES` | all | Restrict NVIDIA GPU visibility |
+
+## Troubleshooting
+
+**Ollama doesn't detect my GPU**
+
+- NVIDIA: ensure `nvidia-smi` works. If not, install/update drivers.
+- Apple Silicon: ensure you're on macOS 13+. Check `uname -m` shows `arm64`.
+- Docker: pass `--gpus all` flag when running Ollama in a container.
+
+**Out of memory errors**
+
+- Reduce `OLLAMA_NUM_GPU` to offload fewer layers to GPU.
+- Use a smaller model (`gemma3:1b` instead of `gemma3:4b`).
+- Set `OLLAMA_NUM_PARALLEL=1` to prevent concurrent model loading.
+
+**Slow inference on CPU**
+
+- Expected. CPU inference is 5-10x slower than GPU.
+- Use `gemma3:1b` for distillation — quality is acceptable for fact extraction.
+- Embedding speed is less affected since `nomic-embed-text` is a small model.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -22,6 +22,8 @@ All settings are controlled via environment variables (or a `.env` file). Defaul
 | `LLM_MODEL` | `gemma3:4b` | Model for distillation |
 | `EMBEDDING_MODEL` | `nomic-embed-text` | Model for embeddings (must produce 768-dim vectors) |
 
+Ollama also reads its own environment variables for GPU control (`OLLAMA_NUM_GPU`, `CUDA_VISIBLE_DEVICES`, etc.). See the [GPU Setup guide](../how-to/gpu-setup.md) for hardware-specific configuration.
+
 ## Privacy & review
 
 | Variable | Default | Description |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - Getting Started: tutorials/getting-started.md
   - How-To Guides:
     - Installation: how-to/installation.md
+    - GPU Setup: how-to/gpu-setup.md
     - GCP Backend: how-to/gcp-backend.md
   - Reference:
     - MCP Tools: reference/tools.md

--- a/src/distill_mcp/__main__.py
+++ b/src/distill_mcp/__main__.py
@@ -87,6 +87,15 @@ def _run_server() -> None:
 
 
 def main() -> None:
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "check-hardware":
+        from distill_mcp.hardware import detect_hardware, format_report
+
+        info = detect_hardware()
+        print(format_report(info))
+        return
+
     _run_server()
 
 

--- a/src/distill_mcp/hardware.py
+++ b/src/distill_mcp/hardware.py
@@ -1,0 +1,132 @@
+"""Hardware detection for Ollama GPU setup guidance."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+
+
+def detect_hardware() -> dict:
+    """Detect available hardware accelerators and Ollama status."""
+    result: dict = {
+        "platform": platform.system(),
+        "arch": platform.machine(),
+        "accelerator": "cpu",
+        "gpu_name": None,
+        "ollama_installed": shutil.which("ollama") is not None,
+        "ollama_running": False,
+        "recommendations": [],
+    }
+
+    # Check NVIDIA GPU
+    if shutil.which("nvidia-smi"):
+        try:
+            out = subprocess.run(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=name,memory.total",
+                    "--format=csv,noheader",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if out.returncode == 0 and out.stdout.strip():
+                result["accelerator"] = "cuda"
+                result["gpu_name"] = out.stdout.strip().split("\n")[0]
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    # Check Apple Silicon
+    if result["platform"] == "Darwin" and result["arch"] == "arm64":
+        result["accelerator"] = "metal"
+        result["gpu_name"] = _get_apple_chip_name()
+
+    # Check Ollama running
+    if result["ollama_installed"]:
+        try:
+            import httpx
+
+            resp = httpx.get("http://localhost:11434/api/version", timeout=2)
+            if resp.status_code == 200:
+                result["ollama_running"] = True
+                result["ollama_version"] = resp.json().get("version", "unknown")
+        except Exception:
+            pass
+
+    result["recommendations"] = _build_recommendations(result)
+    return result
+
+
+def _get_apple_chip_name() -> str | None:
+    """Get Apple Silicon chip name via sysctl."""
+    try:
+        out = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return "Apple Silicon"
+
+
+def _build_recommendations(info: dict) -> list[str]:
+    recs = []
+
+    if not info["ollama_installed"]:
+        recs.append("Install Ollama: https://ollama.com/download")
+    elif not info["ollama_running"]:
+        recs.append("Start Ollama: ollama serve")
+
+    if info["accelerator"] == "cuda":
+        recs.append("NVIDIA GPU detected — Ollama will use CUDA automatically")
+        recs.append(
+            "To limit GPU layers: export OLLAMA_NUM_GPU=999 (all) or 0 (CPU only)"
+        )
+        recs.append("Recommended models: gemma3:4b (distill), nomic-embed-text (embed)")
+    elif info["accelerator"] == "metal":
+        recs.append(
+            "Apple Silicon detected — Ollama uses Metal acceleration by default"
+        )
+        recs.append("Recommended models: gemma3:4b (distill), nomic-embed-text (embed)")
+    else:
+        recs.append("No GPU detected — Ollama will run on CPU (slower but functional)")
+        recs.append(
+            "Consider smaller models for faster inference: gemma3:1b, all-minilm"
+        )
+        recs.append("Set OLLAMA_NUM_PARALLEL=1 to reduce memory pressure")
+
+    return recs
+
+
+def format_report(info: dict) -> str:
+    """Format hardware detection results as a human-readable report."""
+    lines = [
+        "Hardware Detection Report",
+        "=" * 40,
+        f"Platform:     {info['platform']} ({info['arch']})",
+        f"Accelerator:  {info['accelerator'].upper()}",
+    ]
+    if info["gpu_name"]:
+        lines.append(f"GPU:          {info['gpu_name']}")
+
+    lines.append(
+        f"Ollama:       {'installed' if info['ollama_installed'] else 'not found'}"
+    )
+    if info["ollama_running"]:
+        lines.append(f"              running (v{info.get('ollama_version', '?')})")
+    elif info["ollama_installed"]:
+        lines.append("              not running")
+
+    if info["recommendations"]:
+        lines.append("")
+        lines.append("Recommendations:")
+        for rec in info["recommendations"]:
+            lines.append(f"  - {rec}")
+
+    return "\n".join(lines)

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,109 @@
+"""Tests for hardware detection module."""
+
+from unittest.mock import patch
+
+from distill_mcp.hardware import _build_recommendations, detect_hardware, format_report
+
+
+def test_detect_hardware_returns_expected_keys():
+    info = detect_hardware()
+    assert "platform" in info
+    assert "arch" in info
+    assert "accelerator" in info
+    assert "ollama_installed" in info
+    assert "ollama_running" in info
+    assert "recommendations" in info
+    assert info["accelerator"] in ("cuda", "metal", "cpu")
+
+
+def test_recommendations_cpu_fallback():
+    info = {
+        "accelerator": "cpu",
+        "ollama_installed": True,
+        "ollama_running": True,
+    }
+    recs = _build_recommendations(info)
+    assert any("CPU" in r for r in recs)
+    assert any("OLLAMA_NUM_PARALLEL" in r for r in recs)
+
+
+def test_recommendations_cuda():
+    info = {
+        "accelerator": "cuda",
+        "ollama_installed": True,
+        "ollama_running": True,
+    }
+    recs = _build_recommendations(info)
+    assert any("NVIDIA" in r for r in recs)
+    assert any("OLLAMA_NUM_GPU" in r for r in recs)
+
+
+def test_recommendations_metal():
+    info = {
+        "accelerator": "metal",
+        "ollama_installed": True,
+        "ollama_running": True,
+    }
+    recs = _build_recommendations(info)
+    assert any("Apple Silicon" in r for r in recs)
+
+
+def test_recommendations_ollama_not_installed():
+    info = {
+        "accelerator": "cpu",
+        "ollama_installed": False,
+        "ollama_running": False,
+    }
+    recs = _build_recommendations(info)
+    assert any("Install Ollama" in r for r in recs)
+
+
+def test_recommendations_ollama_not_running():
+    info = {
+        "accelerator": "cpu",
+        "ollama_installed": True,
+        "ollama_running": False,
+    }
+    recs = _build_recommendations(info)
+    assert any("ollama serve" in r for r in recs)
+
+
+def test_format_report_includes_key_info():
+    info = {
+        "platform": "Linux",
+        "arch": "x86_64",
+        "accelerator": "cuda",
+        "gpu_name": "NVIDIA RTX 3090, 24576 MiB",
+        "ollama_installed": True,
+        "ollama_running": True,
+        "ollama_version": "0.6.2",
+        "recommendations": ["NVIDIA GPU detected"],
+    }
+    report = format_report(info)
+    assert "Linux" in report
+    assert "CUDA" in report
+    assert "RTX 3090" in report
+    assert "running" in report
+
+
+def test_format_report_no_gpu():
+    info = {
+        "platform": "Linux",
+        "arch": "x86_64",
+        "accelerator": "cpu",
+        "gpu_name": None,
+        "ollama_installed": False,
+        "ollama_running": False,
+        "recommendations": ["Install Ollama"],
+    }
+    report = format_report(info)
+    assert "CPU" in report
+    assert "not found" in report
+
+
+@patch("distill_mcp.hardware.shutil.which", return_value=None)
+def test_detect_hardware_no_tools(mock_which):
+    """When neither nvidia-smi nor ollama are found, falls back to CPU."""
+    info = detect_hardware()
+    assert info["accelerator"] in ("cpu", "metal")  # metal on macOS ARM
+    assert not info["ollama_installed"]


### PR DESCRIPTION
## Summary

- Add `distill check-hardware` CLI command that detects GPU type (NVIDIA CUDA, Apple Metal, CPU-only) and prints setup recommendations
- Add comprehensive GPU setup guide at `docs/how-to/gpu-setup.md` covering all three platforms
- Document Ollama GPU env vars (`OLLAMA_NUM_GPU`, `CUDA_VISIBLE_DEVICES`, etc.) in configuration reference

## Changes

- `src/distill_mcp/hardware.py` — hardware detection module (nvidia-smi, platform detection, Ollama status check)
- `src/distill_mcp/__main__.py` — `check-hardware` subcommand routing
- `docs/how-to/gpu-setup.md` — setup guide with model recommendations, performance expectations, and troubleshooting
- `docs/reference/configuration.md` — cross-reference to GPU setup guide
- `mkdocs.yml` — nav entry for GPU Setup page
- `tests/test_hardware.py` — 9 unit tests for detection and recommendation logic

## Test plan

- [x] Unit tests pass (148 passed, 12 ollama deselected)
- [x] `distill check-hardware` verified — correctly detects RTX 5070 Ti with CUDA
- [ ] Manual verification on macOS (Metal detection)

Closes #22