### PR TITLE
docs: add Neon PostgreSQL backend guide

### DIFF
--- a/docs/how-to/neon-backend.md
+++ b/docs/how-to/neon-backend.md
@@ -1,0 +1,60 @@
+---
+title: Neon Backend Setup
+---
+
+# Neon Backend Setup
+
+[Neon](https://neon.tech) is a serverless PostgreSQL provider with a generous free tier. It supports pgvector natively, making it a zero-cost alternative to Cloud SQL for the PostgreSQL backend.
+
+## Prerequisites
+
+- A Neon account (free tier works)
+- Ollama running locally (distillation always stays local)
+
+## Step 1: Create a Neon project
+
+1. Go to [console.neon.tech](https://console.neon.tech) and create a new project
+2. Choose a region close to you
+3. Copy the connection string
+
+## Step 2: Enable pgvector
+
+In the Neon SQL Editor, run:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+## Step 3: Configure environment
+
+```bash
+export BACKEND=gcp
+export DATABASE_URL="postgresql://user:pass@ep-xyz.us-east-2.aws.neon.tech/distill?sslmode=require"
+```
+
+`BACKEND=gcp` selects the PostgreSQL adapter — it works with any PostgreSQL provider, not just GCP.
+
+## Step 4: Start Distill
+
+```bash
+python -m distill_mcp
+```
+
+The PostgreSQL store will automatically create the `memories` table, full-text search indexes, and RLS policies.
+
+## Connection pooling caveat
+
+Neon offers two connection endpoints:
+
+| Endpoint | Example | Session variables |
+|----------|---------|-------------------|
+| **Direct** | `ep-xyz.us-east-2.aws.neon.tech` | Work correctly |
+| **Pooled** | `ep-xyz-pooler.us-east-2.aws.neon.tech` | Lost between transactions |
+
+If you use `AUTH_ENABLED=true`, you **must** use the direct endpoint. The RLS implementation relies on session-level `SET` commands (`app.repos`, `app.user_email`) that PgBouncer's transaction mode discards.
+
+With auth disabled (default), either endpoint works.
+
+## Cost
+
+**Free.** Neon's free tier includes 0.5 GB storage and 190 compute hours/month — more than sufficient for team memory.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -54,14 +54,14 @@ Cross-encoder reranking improves search relevance by re-scoring results after hy
 
 Reranking adds latency (~200ms) and requires an external API call. Only recommended for GCP backend where search quality is critical. The privacy constraint is preserved — only distilled content (never raw input) is sent to the reranker.
 
-## GCP settings
+## PostgreSQL settings
 
-Only used when `BACKEND=gcp`.
+Used when `BACKEND=gcp`. Works with any PostgreSQL provider that supports pgvector (Cloud SQL, [Neon](../how-to/neon-backend.md), Supabase, self-hosted).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | — | PostgreSQL connection string |
-| `GCP_PROJECT` | — | GCP project ID |
+| `GCP_PROJECT` | — | GCP project ID (Cloud SQL / Vertex AI only) |
 | `GCP_LOCATION` | `us-central1` | GCP region for Vertex AI |
 | `CLOUD_SQL_CONNECTION` | — | Cloud SQL instance connection name |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
     - GPU Setup: how-to/gpu-setup.md
     - Seed from Git: how-to/seed-from-git.md
     - GCP Backend: how-to/gcp-backend.md
+    - Neon Backend: how-to/neon-backend.md
   - Reference:
     - MCP Tools: reference/tools.md
     - Configuration: reference/configuration.md


### PR DESCRIPTION
## Summary
- Adds how-to guide for using Neon (free serverless PostgreSQL) as an alternative to Cloud SQL
- Documents the connection pooling caveat: direct endpoint required when `AUTH_ENABLED=true` (session-level `SET` vs PgBouncer transaction mode)
- Renames "GCP settings" → "PostgreSQL settings" in configuration reference to reflect provider-agnostic support

## Changes
- `docs/how-to/neon-backend.md` — new guide
- `docs/reference/configuration.md` — section rename + Neon cross-link
- `mkdocs.yml` — nav entry

## Test plan
- [x] Unit tests pass (148 passed)
- [ ] `mkdocs serve` renders the new page correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)