### PR TITLE
feat: expose seed workflow as MCP prompt

### DIFF
--- a/src/distill_mcp/server.py
+++ b/src/distill_mcp/server.py
@@ -1,8 +1,9 @@
-"""MCP server — thin adapter exposing 8 tools. No business logic here."""
+"""MCP server — thin adapter exposing 8 tools + 1 prompt. No business logic here."""
 
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
@@ -334,3 +335,12 @@ async def forget(id: str, agent_id: str | None = None) -> dict:
     """
     logger.info("tool_invoked", tool="forget", id=id)
     return await _svc().forget(id, agent_id=agent_id)
+
+
+_SEED_WORKFLOW = (Path(__file__).parent / "skills" / "seed" / "SKILL.md").read_text()
+
+
+@mcp.prompt(description="Populate distill knowledge base from git history")
+def seed() -> str:
+    """Return the seed-from-git workflow."""
+    return _SEED_WORKFLOW


### PR DESCRIPTION
## Summary
- Registers the seed workflow (`skills/seed/SKILL.md`) as an `@mcp.prompt` so `/seed` is available in any project that adds distill as an MCP server
- Previously only accessible via Claude Code's `additionalDirectories` setting (local to this repo)
- Content is lazy: `prompts/list` shows only name + description; full 113-line workflow loads only on `prompts/get`

## Changes
- `server.py`: Added `Path` import, `_SEED_WORKFLOW` module-level constant, `@mcp.prompt` decorated `seed()` function

## Test plan
- [x] 148 tests pass (`pytest -k "not ollama"`)
- [ ] Manual: `claude mcp add distill -- python -m distill_mcp` in another project → `/seed` appears