### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distill-mcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "Privacy-first team memory MCP server — local LLM distillation before team sync"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Version bump to 0.1.2 to trigger PyPI publish with the fixed README (rendered flow diagram instead of raw Mermaid)

## Test plan
- [x] No code changes, version bump only