### PR TITLE
fix: include skills/ directory in wheel distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ distill = "distill_mcp.__main__:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/distill_mcp"]
+artifacts = ["*.md"]
 
 # --- Ruff ---
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "distill-mcp"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "detect-secrets" },


### PR DESCRIPTION
## Summary
- The `skills/seed/SKILL.md` data file was excluded from the wheel build, causing the MCP server to crash on startup with `FileNotFoundError`
- Adds `artifacts = ["*.md"]` to the hatch wheel config so non-Python files inside the package tree are included

## Changes
- `pyproject.toml`: added `artifacts = ["*.md"]` under `[tool.hatch.build.targets.wheel]`

## Test plan
- [x] All 151 tests pass
- [x] Built wheel verified to contain `distill_mcp/skills/seed/SKILL.md`
- [x] `python -m distill_mcp` starts successfully after `pip install` from wheel