### PR TITLE
feat: multi-level memory with search ranking (#57)

### DIFF
--- a/src/distill_mcp/domain/models.py
+++ b/src/distill_mcp/domain/models.py
@@ -26,6 +26,20 @@ class SearchResult:
     score: float  # RRF hybrid score
 
 
+def derive_level(memory_type: str, repos: list[str]) -> str:
+    """Derive memory level from type and repo scope.
+
+    - short-term: ephemeral context
+    - long-term: durable decisions, patterns, failures, dependencies
+    - shared: applies across multiple repos
+    """
+    if len(repos) > 1:
+        return "shared"
+    if memory_type == "context":
+        return "short-term"
+    return "long-term"
+
+
 @dataclass
 class MemoryIndex:
     """Compact search result for progressive disclosure (Layer 1)."""
@@ -37,6 +51,7 @@ class MemoryIndex:
     score: float
     created_at: datetime
     est_tokens: int  # len(content) // 4
+    level: str = ""
     agent_id: str | None = None
 
 
@@ -52,5 +67,6 @@ class MemoryDetail:
     score: float | None
     created_at: datetime
     author: str | None
+    level: str = ""
     agent_id: str | None = None
     est_tokens: int = 0

--- a/src/distill_mcp/domain/services.py
+++ b/src/distill_mcp/domain/services.py
@@ -50,6 +50,13 @@ MIN_SEARCH_SCORE = 0.35
 RECENCY_WEIGHT = 0.15
 ACCESS_BOOST_WEIGHT = 0.1
 
+# Level-aware scoring multipliers
+LEVEL_BOOST: dict[str, float] = {
+    "short-term": 0.8,  # ephemeral context ranks lower
+    "long-term": 1.0,  # baseline for durable knowledge
+    "shared": 1.2,  # cross-repo knowledge ranks higher
+}
+
 # Weibull decay parameters per memory type: (scale λ in days, shape k)
 # S(t) = exp(-(t/λ)^k)  — 1.0 at t=0, decays toward 0
 WEIBULL_PARAMS: dict[str, tuple[float, float]] = {
@@ -81,7 +88,7 @@ class _PendingEntry:
 
 def _to_index(memory: Memory, score: float = 0.0) -> MemoryIndex:
     """Convert a Memory to a compact MemoryIndex for progressive disclosure."""
-    from distill_mcp.domain.models import MemoryIndex
+    from distill_mcp.domain.models import MemoryIndex, derive_level
 
     snippet = memory.content[:80] + ("..." if len(memory.content) > 80 else "")
     return MemoryIndex(
@@ -92,13 +99,14 @@ def _to_index(memory: Memory, score: float = 0.0) -> MemoryIndex:
         score=score,
         created_at=memory.created_at,
         est_tokens=len(memory.content) // 4,
+        level=derive_level(memory.type, memory.repos),
         agent_id=memory.agent_id,
     )
 
 
 def _to_detail(memory: Memory, score: float | None = None) -> MemoryDetail:
     """Convert a Memory to a full MemoryDetail."""
-    from distill_mcp.domain.models import MemoryDetail
+    from distill_mcp.domain.models import MemoryDetail, derive_level
 
     return MemoryDetail(
         id=memory.id,
@@ -109,6 +117,7 @@ def _to_detail(memory: Memory, score: float | None = None) -> MemoryDetail:
         score=score,
         created_at=memory.created_at,
         author=memory.author,
+        level=derive_level(memory.type, memory.repos),
         agent_id=memory.agent_id,
         est_tokens=len(memory.content) // 4,
     )
@@ -464,6 +473,13 @@ class MemoryService:
         for r in results:
             access_boost = math.log(r.memory.access_count + 1) * ACCESS_BOOST_WEIGHT
             r.score *= 1.0 + access_boost
+
+        # Level-aware boost — shared knowledge ranks higher, ephemeral lower
+        from distill_mcp.domain.models import derive_level
+
+        for r in results:
+            level = derive_level(r.memory.type, r.memory.repos)
+            r.score *= LEVEL_BOOST.get(level, 1.0)
 
         results = [r for r in results if r.score >= MIN_SEARCH_SCORE]
         results.sort(key=lambda r: r.score, reverse=True)

--- a/src/distill_mcp/server.py
+++ b/src/distill_mcp/server.py
@@ -194,6 +194,7 @@ async def search_memory(
         {
             "id": r.id,
             "type": r.type,
+            "level": r.level,
             "snippet": r.snippet,
             "repos": r.repos,
             "score": round(r.score, 4),
@@ -222,6 +223,7 @@ async def get_memories(ids: list[str]) -> list[dict]:
             "id": d.id,
             "content": d.content,
             "type": d.type,
+            "level": d.level,
             "repos": d.repos,
             "tags": d.tags,
             "score": d.score,
@@ -299,6 +301,7 @@ async def list_recent(
         {
             "id": m.id,
             "type": m.type,
+            "level": m.level,
             "snippet": m.snippet,
             "repos": m.repos,
             "created_at": m.created_at.isoformat(),

--- a/tests/test_memory_levels.py
+++ b/tests/test_memory_levels.py
@@ -1,0 +1,184 @@
+"""Memory levels — derive level from type/repos, boost search scoring.
+
+Covers issue #57: multi-level memory with search ranking impact.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from distill_mcp.domain.models import Memory, SearchResult, derive_level
+from distill_mcp.domain.services import LEVEL_BOOST, MemoryService
+
+
+class TestDeriveLevel:
+    """Level derivation from type and repo scope."""
+
+    def test_context_is_short_term(self) -> None:
+        assert derive_level("context", ["repo"]) == "short-term"
+
+    def test_decision_is_long_term(self) -> None:
+        assert derive_level("decision", ["repo"]) == "long-term"
+
+    def test_pattern_is_long_term(self) -> None:
+        assert derive_level("pattern", ["repo"]) == "long-term"
+
+    def test_failure_is_long_term(self) -> None:
+        assert derive_level("failure", ["repo"]) == "long-term"
+
+    def test_dependency_is_long_term(self) -> None:
+        assert derive_level("dependency", ["repo"]) == "long-term"
+
+    def test_multi_repo_is_shared(self) -> None:
+        assert derive_level("decision", ["repo-a", "repo-b"]) == "shared"
+
+    def test_multi_repo_context_is_shared(self) -> None:
+        # Multi-repo takes precedence over type
+        assert derive_level("context", ["repo-a", "repo-b"]) == "shared"
+
+    def test_empty_repos_is_not_shared(self) -> None:
+        assert derive_level("decision", []) == "long-term"
+
+    def test_single_repo_is_not_shared(self) -> None:
+        assert derive_level("decision", ["repo"]) == "long-term"
+
+    def test_unknown_type_is_long_term(self) -> None:
+        assert derive_level("unknown", ["repo"]) == "long-term"
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# -- Level in search results --
+
+
+class FakeDistiller:
+    async def distill(self, raw_text: str) -> str:
+        return "Distilled fact"
+
+
+class FakeEmbedder:
+    async def embed(self, text: str) -> list[float]:
+        return [0.5] * 768
+
+
+class FakeStorage:
+    def __init__(self) -> None:
+        self._memories: dict[str, tuple[Memory, float]] = {}
+
+    async def check_duplicate(self, vec, threshold=0.95):
+        return None
+
+    async def save(self, memory, vec, **kw):
+        self._memories[memory.id] = (memory, 0.9)
+        return memory.id
+
+    async def get(self, id):
+        pair = self._memories.get(id)
+        return pair[0] if pair else None
+
+    async def delete(self, id):
+        self._memories.pop(id, None)
+
+    async def search(self, query_text, query_vec, top_k, *, repo=None, agent_id=None):
+        results = []
+        for mem, score in self._memories.values():
+            if repo is not None and repo not in mem.repos:
+                continue
+            if agent_id is not None and mem.agent_id != agent_id:
+                continue
+            results.append(SearchResult(memory=mem, score=score))
+        return results[:top_k]
+
+    async def list_recent(self, **kw):
+        return [m for m, _ in self._memories.values()]
+
+    async def record_access(self, id):
+        pass
+
+    async def find_related(self, vec, *, threshold=0.80, top_k=3, repo=None):
+        return []
+
+
+def _make_memory(type: str, repos: list[str], content: str = "fact") -> Memory:
+    return Memory(
+        id=f"{type}-{'-'.join(repos)}",
+        content=content,
+        type=type,
+        repos=repos,
+        tags=[],
+        author=None,
+        created_at=datetime.now(UTC),
+    )
+
+
+class TestLevelInResults:
+    """Level should appear in MemoryIndex from search and list_recent."""
+
+    async def test_search_returns_level(self) -> None:
+        storage = FakeStorage()
+        svc = MemoryService(
+            storage=storage,
+            embedder=FakeEmbedder(),
+            distiller=FakeDistiller(),
+            preview_enabled=False,
+        )
+        await svc.remember(
+            "We chose PostgreSQL for pgvector support", "decision", ["repo"]
+        )
+        results = await svc.search("PostgreSQL", top_k=5)
+        assert len(results) >= 1
+        assert results[0].level == "long-term"
+
+    async def test_list_recent_returns_level(self) -> None:
+        storage = FakeStorage()
+        svc = MemoryService(
+            storage=storage,
+            embedder=FakeEmbedder(),
+            distiller=FakeDistiller(),
+            preview_enabled=False,
+        )
+        await svc.remember(
+            "Temporary context about debugging the OOM issue", "context", ["repo"]
+        )
+        results = await svc.list_recent()
+        assert len(results) >= 1
+        assert results[0].level == "short-term"
+
+
+class TestLevelBoost:
+    """Search scoring should be multiplied by level coefficient."""
+
+    def test_shared_boost_is_higher(self) -> None:
+        assert LEVEL_BOOST["shared"] > LEVEL_BOOST["long-term"]
+
+    def test_short_term_boost_is_lower(self) -> None:
+        assert LEVEL_BOOST["short-term"] < LEVEL_BOOST["long-term"]
+
+    async def test_shared_memory_scores_higher_than_single_repo(self) -> None:
+        """A shared memory with same base score should rank higher."""
+        storage = FakeStorage()
+        svc = MemoryService(
+            storage=storage,
+            embedder=FakeEmbedder(),
+            distiller=FakeDistiller(),
+            preview_enabled=False,
+        )
+
+        # Create a single-repo decision
+        mem_single = _make_memory("decision", ["repo-a"], "Use PostgreSQL for storage")
+        storage._memories[mem_single.id] = (mem_single, 0.9)
+
+        # Create a shared decision (same base score)
+        mem_shared = _make_memory(
+            "decision", ["repo-a", "repo-b"], "Use PostgreSQL everywhere"
+        )
+        storage._memories[mem_shared.id] = (mem_shared, 0.9)
+
+        results = await svc.search("PostgreSQL", top_k=10)
+        scores = {r.id: r.score for r in results}
+
+        # Shared memory should have a higher final score
+        assert scores[mem_shared.id] > scores[mem_single.id]


### PR DESCRIPTION
## Summary
- Memories now have a **level** derived from type and repo scope: `short-term` (context), `long-term` (decision/pattern/failure/dependency), `shared` (multi-repo)
- Search scoring applies a level-aware multiplier: short-term ×0.8, long-term ×1.0, shared ×1.2
- Level is returned in `search_memory`, `get_memories`, and `list_recent` responses

## Changes
- `domain/models.py`: `derive_level()` function, `level` field on `MemoryIndex` and `MemoryDetail`
- `domain/services.py`: `LEVEL_BOOST` constants, level boost in search pipeline, `derive_level` calls in `_to_index`/`_to_detail`
- `server.py`: `level` field in all response dicts
- `tests/test_memory_levels.py`: 15 tests

## Test plan
- [x] All 196 tests pass (181 existing + 15 new, excluding 12 Ollama-dependent)
- [x] All pre-commit hooks pass
- [x] Tests cover: all type→level mappings, multi-repo→shared, level in search/list results, boost ordering

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)