### PR TITLE
feat: distill export command with JSON/CSV output (#17)

### DIFF
--- a/src/distill_mcp/__main__.py
+++ b/src/distill_mcp/__main__.py
@@ -1,7 +1,39 @@
 """Entry point — wires adapters, injects into service, starts MCP server."""
 
+from __future__ import annotations
+
+
+def _init_store() -> tuple:
+    """Initialize storage adapter based on backend config.
+
+    Returns (store, needs_async_init, identity).
+    Caller must handle async init if needed.
+    """
+    from distill_mcp.settings import settings
+
+    identity = None
+    if settings.auth_enabled:
+        from distill_mcp.adapters.identity.git_identity import resolve_git_identity
+
+        identity = resolve_git_identity()
+
+    if settings.backend in ("gcp", "postgres"):
+        from distill_mcp.adapters.storage.postgres_store import PostgresStore
+
+        if settings.backend == "gcp" and not settings.gcp_project:
+            raise RuntimeError("GCP_PROJECT is required when BACKEND=gcp")
+
+        store = PostgresStore(dsn=settings.database_url, identity=identity)
+        return store, True, identity
+    else:
+        from distill_mcp.adapters.storage.sqlite_store import SqliteStore
+
+        store = SqliteStore(settings.data_dir, rrf_k=settings.rrf_k)
+        return store, False, identity
+
 
 def _run_server() -> None:
+    import asyncio
     from pathlib import Path
 
     from distill_mcp.adapters.distiller.ollama_distill import OllamaDistiller
@@ -10,45 +42,22 @@ def _run_server() -> None:
     from distill_mcp.server import mcp, set_service
     from distill_mcp.settings import settings
 
-    # Resolve identity when auth is enabled
-    identity = None
-    if settings.auth_enabled:
-        from distill_mcp.adapters.identity.git_identity import resolve_git_identity
-
-        identity = resolve_git_identity()
+    store, needs_async_init, identity = _init_store()
+    if needs_async_init:
+        asyncio.get_event_loop().run_until_complete(store.initialize())
+    else:
+        store.initialize()
 
     if settings.backend == "gcp":
-        import asyncio
-
         from distill_mcp.adapters.embeddings.vertex_embed import VertexEmbedder
-        from distill_mcp.adapters.storage.postgres_store import PostgresStore
 
-        if not settings.gcp_project:
-            raise RuntimeError("GCP_PROJECT is required when BACKEND=gcp")
-
-        store = PostgresStore(dsn=settings.database_url, identity=identity)
-        asyncio.get_event_loop().run_until_complete(store.initialize())
         embedder = VertexEmbedder(
-            project=settings.gcp_project,
+            project=settings.gcp_project or "",
             location=settings.gcp_location,
-        )
-    elif settings.backend == "postgres":
-        import asyncio
-
-        from distill_mcp.adapters.embeddings.ollama_embed import OllamaEmbedder
-        from distill_mcp.adapters.storage.postgres_store import PostgresStore
-
-        store = PostgresStore(dsn=settings.database_url, identity=identity)
-        asyncio.get_event_loop().run_until_complete(store.initialize())
-        embedder = OllamaEmbedder(
-            host=settings.ollama_host, model=settings.embedding_model
         )
     else:
         from distill_mcp.adapters.embeddings.ollama_embed import OllamaEmbedder
-        from distill_mcp.adapters.storage.sqlite_store import SqliteStore
 
-        store = SqliteStore(settings.data_dir, rrf_k=settings.rrf_k)
-        store.initialize()
         embedder = OllamaEmbedder(
             host=settings.ollama_host, model=settings.embedding_model
         )
@@ -86,6 +95,82 @@ def _run_server() -> None:
     mcp.run(transport="stdio")
 
 
+def _export_memories(
+    fmt: str,
+    output: str | None,
+    repo: str | None,
+    type_filter: str | None,
+    after: str | None,
+) -> None:
+    import asyncio
+    import csv
+    import io
+    import json
+    import sys
+    from dataclasses import asdict
+    from datetime import datetime
+
+    store, needs_async_init, _identity = _init_store()
+    if needs_async_init:
+        asyncio.get_event_loop().run_until_complete(store.initialize())
+    else:
+        store.initialize()
+
+    memories = asyncio.get_event_loop().run_until_complete(
+        store.list_recent(repo=repo, type=type_filter, limit=10000)
+    )
+
+    if after:
+        cutoff = datetime.fromisoformat(after)
+        memories = [m for m in memories if m.created_at >= cutoff]
+
+    fields = [
+        "id",
+        "content",
+        "type",
+        "repos",
+        "tags",
+        "author",
+        "created_at",
+        "access_count",
+        "last_accessed_at",
+        "agent_id",
+    ]
+
+    def _serialize(obj: object) -> str:
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f"Not serializable: {type(obj)}")
+
+    rows = []
+    for m in memories:
+        d = asdict(m)
+        rows.append({k: d[k] for k in fields})
+
+    if fmt == "csv":
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            row["repos"] = ";".join(row["repos"])
+            row["tags"] = ";".join(row["tags"])
+            if row["created_at"]:
+                row["created_at"] = row["created_at"].isoformat()
+            if row["last_accessed_at"]:
+                row["last_accessed_at"] = row["last_accessed_at"].isoformat()
+            writer.writerow(row)
+        text = buf.getvalue()
+    else:
+        text = json.dumps(rows, default=_serialize, indent=2)
+
+    if output:
+        with open(output, "w") as f:
+            f.write(text)
+        print(f"Exported {len(rows)} memories to {output}", file=sys.stderr)
+    else:
+        print(text)
+
+
 def _print_seed_workflow() -> None:
     from pathlib import Path
 
@@ -106,6 +191,38 @@ def main() -> None:
             return
         if cmd == "seed":
             _print_seed_workflow()
+            return
+        if cmd == "export":
+            args = sys.argv[2:]
+            fmt = "json"
+            output = None
+            repo = None
+            type_filter = None
+            after = None
+            i = 0
+            while i < len(args):
+                if args[i] == "--format" and i + 1 < len(args):
+                    fmt = args[i + 1]
+                    i += 2
+                elif args[i] == "--output" and i + 1 < len(args):
+                    output = args[i + 1]
+                    i += 2
+                elif args[i] == "--repo" and i + 1 < len(args):
+                    repo = args[i + 1]
+                    i += 2
+                elif args[i] == "--type" and i + 1 < len(args):
+                    type_filter = args[i + 1]
+                    i += 2
+                elif args[i] == "--after" and i + 1 < len(args):
+                    after = args[i + 1]
+                    i += 2
+                else:
+                    print(f"Unknown argument: {args[i]}", file=sys.stderr)
+                    sys.exit(1)
+            if fmt not in ("json", "csv"):
+                print(f"Unsupported format: {fmt}", file=sys.stderr)
+                sys.exit(1)
+            _export_memories(fmt, output, repo, type_filter, after)
             return
 
     _run_server()


### PR DESCRIPTION
## Summary
- New `distill export` CLI command for data export — Phase 1 of knowledge timeline
- Supports `--format json` (default) and `--format csv`
- Filters: `--repo`, `--type`, `--after YYYY-MM-DD`
- Output to stdout or `--output file.json`

## Changes
- `__main__.py`: Extracted `_init_store()` helper, added `_export_memories()` and arg parser
- No new dependencies — uses stdlib `json` and `csv`

## Test plan
- [x] All 205 tests pass (excluding 12 Ollama-dependent)
- [x] All pre-commit hooks pass (including ty type check)
- [ ] Manual: `distill export --format json`, `distill export --format csv --repo distill`

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)