### PR TITLE
feat: add Gemini provider and decouple storage/embedding/distillation config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,43 @@
-BACKEND=local
+# --- Storage ---
+BACKEND=local              # local | postgres
 DATA_DIR=~/.team-memory
+# DATABASE_URL=postgresql://user:pass@localhost:5432/distill
+
+# --- Embedding provider ---
+EMBEDDING_PROVIDER=ollama  # ollama | gemini | vertex | bedrock | azure
+# EMBEDDING_MODEL=          # optional, default per provider:
+#   ollama  → nomic-embed-text
+#   gemini  → text-embedding-004
+#   vertex  → text-embedding-005
+#   bedrock → amazon.titan-embed-text-v2:0
+#   azure   → text-embedding-3-small
+
+# --- Distillation provider ---
+DISTILLER_PROVIDER=ollama  # ollama | gemini
+# LLM_MODEL=                # optional, default per provider:
+#   ollama → gemma3:4b
+#   gemini → gemini-2.0-flash
+
+# --- Provider credentials ---
+
+# Ollama (default, no credentials needed)
 OLLAMA_HOST=http://localhost:11434
-EMBEDDING_MODEL=nomic-embed-text
-LLM_MODEL=gemma3:4b
+
+# Gemini (get a free key at https://aistudio.google.com/apikey)
+# GEMINI_API_KEY=your-key-here
+
+# Vertex AI
+# GCP_PROJECT=your-project-id
+# GCP_LOCATION=us-central1
+
+# Bedrock (uses AWS credential chain)
+# AWS_REGION=us-east-1
+
+# Azure OpenAI
+# AZURE_OPENAI_ENDPOINT=https://your-instance.openai.azure.com
+# AZURE_OPENAI_API_KEY=your-key-here
+
+# --- General ---
 DEFAULT_AUTHOR=yourname
 RRF_K=60
 MAX_MEMORY_SIZE=8000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## What this is
 
-An MCP server that gives Claude Code access to a shared team knowledge base. Raw developer input is distilled into anonymous factual knowledge by a local LLM (Ollama) before anything leaves the device.
+An MCP server that gives Claude Code access to a shared team knowledge base. Raw developer input is distilled into anonymous factual knowledge by an LLM before being stored.
 
 ## Core principle
 
-**The local LLM is the privacy component, not an optional feature.** Raw text → Ollama (local) → distilled fact → team DB. The raw text never crosses a network boundary.
+**By default, the local LLM is the privacy component.** Raw text → Ollama (local) → distilled fact → team DB. Three independent axes: `BACKEND` (storage), `EMBEDDING_PROVIDER`, `DISTILLER_PROVIDER`. Setting `DISTILLER_PROVIDER=gemini` sends raw text to Google instead of keeping it local.
 
 ## Architecture (Uncle Bob / Clean Architecture)
 
@@ -25,9 +25,11 @@ src/distill_mcp/
 │   │   └── postgres_store.py  # StoragePort → asyncpg + pgvector + tsvector
 │   ├── embeddings/
 │   │   ├── ollama_embed.py    # EmbeddingPort → local Ollama
-│   │   └── vertex_embed.py    # EmbeddingPort → Vertex AI
+│   │   ├── vertex_embed.py    # EmbeddingPort → Vertex AI
+│   │   └── gemini_embed.py    # EmbeddingPort → Gemini API
 │   └── distiller/
-│       └── ollama_distill.py  # DistillerPort → local Ollama (always local)
+│       ├── ollama_distill.py  # DistillerPort → local Ollama
+│       └── gemini_distill.py  # DistillerPort → Gemini API
 │
 ├── server.py            # FastMCP tool definitions — thin adapter calling services
 ├── config.py            # pydantic-settings, env var loading
@@ -75,7 +77,7 @@ Every code change follows this sequence. Do not skip steps.
 
 ## What NOT to do
 
-- Never send raw developer input to any cloud API
+- Never send raw developer input to a cloud API unless the user opted in via `DISTILLER_PROVIDER=gemini`
 - Never print to stdout (breaks MCP stdio protocol)
 - Never hardcode API keys
 - Never store author names unless developer opted in via AUTHOR_MODE

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -27,8 +27,8 @@ graph TB
 
     subgraph "Adapters (outer ring)"
         SQL["sqlite_store.py / postgres_store.py"]
-        EMB["ollama_embed.py / vertex_embed.py"]
-        DST["ollama_distill.py"]
+        EMB["ollama_embed.py / vertex_embed.py / gemini_embed.py"]
+        DST["ollama_distill.py / gemini_distill.py"]
         SCN["secret_scanner.py (secrets + PII)"]
         RRK["jina_rerank.py (opt-in)"]
     end
@@ -48,7 +48,9 @@ graph TB
     SCN -.->|implements| PRT
     RRK -.->|implements| PRT
     DST --> OLLAMA
+    DST -.->|or| GEMINI["Gemini API (cloud)"]
     EMB --> OLLAMA
+    EMB -.->|or| GEMINI
     SQL --> DB
     SQL --> VEC
 ```
@@ -68,9 +70,11 @@ src/distill_mcp/
 │   │   └── postgres_store.py  # StoragePort → asyncpg + pgvector + tsvector
 │   ├── embeddings/
 │   │   ├── ollama_embed.py    # EmbeddingPort → local Ollama
-│   │   └── vertex_embed.py    # EmbeddingPort → Vertex AI
+│   │   ├── vertex_embed.py    # EmbeddingPort → Vertex AI
+│   │   └── gemini_embed.py    # EmbeddingPort → Gemini API
 │   ├── distiller/
-│   │   └── ollama_distill.py  # DistillerPort → local Ollama (always local)
+│   │   ├── ollama_distill.py  # DistillerPort → local Ollama
+│   │   └── gemini_distill.py  # DistillerPort → Gemini API
 │   ├── scanner/
 │   │   └── secret_scanner.py  # ScannerPort → secrets + PII redaction
 │   └── reranker/
@@ -87,22 +91,32 @@ src/distill_mcp/
 
 This means you can swap SQLite for PostgreSQL, or Ollama embeddings for Vertex AI, without touching any business logic.
 
-## Backend options
+## Configuration axes
 
-| Backend | Storage | Vectors | Embeddings | Distillation | Cost |
-|---------|---------|---------|------------|--------------|------|
-| `local` | SQLite + FTS5 | LanceDB | Ollama | Ollama | $0 |
-| `gcp` | Cloud SQL PostgreSQL | pgvector | Vertex AI | Ollama (local) | ~$11/mo |
-| `aws` | RDS PostgreSQL | pgvector | Bedrock | Ollama (local) | ~$15/mo |
-| `azure` | Azure Database for PostgreSQL | pgvector | Azure OpenAI | Ollama (local) | ~$14/mo |
+Storage, embeddings, and distillation are configured independently:
 
-Distillation is **always local** regardless of backend — this is the privacy guarantee.
+| Setting | Options |
+|---------|---------|
+| `BACKEND` | `local` (SQLite + LanceDB) or `postgres` (PostgreSQL + pgvector) |
+| `EMBEDDING_PROVIDER` | `ollama`, `gemini`, `vertex`, `bedrock`, `azure` |
+| `DISTILLER_PROVIDER` | `ollama`, `gemini` |
+
+### Example configurations
+
+| Use case | Storage | Embeddings | Distillation | Cost |
+|----------|---------|------------|--------------|------|
+| Local-only | `local` | `ollama` | `ollama` | $0 |
+| Cloud-free (no GPU) | `local` | `gemini` | `gemini` | $0 (free tier) |
+| Team (GCP) | `postgres` | `vertex` | `ollama` | ~$11/mo |
+| Team (GCP, no GPU) | `postgres` | `vertex` | `gemini` | ~$11/mo |
+| Team (AWS) | `postgres` | `bedrock` | `ollama` | ~$15/mo |
+| Team (Azure) | `postgres` | `azure` | `ollama` | ~$14/mo |
 
 ## Key execution flows
 
 ### Remember (two-phase commit)
 
-1. `remember()` sends raw text to local Ollama for distillation
+1. `remember()` sends raw text to the distillation provider
 2. Scanner checks the output for leaked secrets
 3. Dedup check rejects if cosine similarity > 0.95 with existing memory
 4. Returns a preview with `pending_id` — memory is NOT stored yet

--- a/docs/explanation/privacy-model.md
+++ b/docs/explanation/privacy-model.md
@@ -6,9 +6,9 @@ title: Privacy Model
 
 ## The core guarantee
 
-**Your raw text never crosses a network boundary.** The local LLM is not optional — it's the privacy component.
+**With `DISTILLER_PROVIDER=ollama` (default), your raw text never crosses a network boundary.**
 
-```
+```text
 Developer input (raw text)
         │
         ▼
@@ -18,8 +18,7 @@ Developer input (raw text)
           │
           ▼
    ┌─────────────┐
-   │   Ollama     │ ← localhost, never crosses network
-   │  (distill)   │
+   │  Distiller   │ ← ollama: localhost / gemini: Google API
    └──────┬──────┘
           │ distilled fact (no names, no emotion, no PII)
           ▼
@@ -35,13 +34,13 @@ Developer input (raw text)
 
 ## What makes this different
 
-Every "memory MCP" stores your raw text in a database. Distill doesn't. The local LLM is a mandatory privacy gateway that transforms personal thoughts into impersonal team knowledge. Contributing knowledge is psychologically safe because your exact words never leave your machine.
+Every "memory MCP" stores your raw text in a database. Distill doesn't. The LLM is a mandatory privacy gateway that transforms personal thoughts into impersonal team knowledge. With `DISTILLER_PROVIDER=ollama`, your exact words never leave your machine.
 
 ## FAQ
 
 | Question | Answer |
 |----------|--------|
-| Does Anthropic see my raw input? | No. It goes to local Ollama only. |
+| Does Anthropic see my raw input? | No. It goes to the distiller: Ollama (local) or Gemini (Google). |
 | Can my team read what I typed? | No. Only the distilled fact is stored. |
 | Can my manager see who wrote what? | Only if you opt in (`AUTH_ENABLED=true`). Anonymous by default. |
 | Where is my raw text? | `~/.distill/private/` on your machine. Delete anytime. |
@@ -88,3 +87,15 @@ Previously, `confirm_memory` overrides and `update_memory` bypassed the scanner.
 | `AUTH_ENABLED=true` | Git identity (`user.email`) used for ownership and RLS enforcement |
 
 When authentication is enabled, PostgreSQL Row-Level Security policies enforce that only the author can modify or delete their memories. Anonymous users retain read-only search access.
+
+## Cloud distillation (`DISTILLER_PROVIDER=gemini`)
+
+Setting `DISTILLER_PROVIDER=gemini` sends raw text to Google's Gemini API for distillation. This means **raw text leaves your device**.
+
+Use this when:
+
+- Local compute resources are limited (no GPU, low RAM)
+- The privacy tradeoff is acceptable for your team
+- You want $0 cost without running Ollama
+
+The same distillation prompt runs on Gemini — names, emotions, and PII are still stripped. The scanner still checks output for leaked secrets. The difference is the distillation happens in Google's cloud, not on your machine.

--- a/docs/how-to/aws-backend.md
+++ b/docs/how-to/aws-backend.md
@@ -4,7 +4,7 @@ title: AWS Backend Setup
 
 # AWS Backend (RDS + Bedrock)
 
-The AWS backend uses Amazon RDS PostgreSQL with pgvector for storage and Amazon Bedrock Titan Embed v2 for embeddings. Distillation still runs locally via Ollama — the privacy guarantee is preserved.
+The AWS setup uses Amazon RDS PostgreSQL with pgvector for storage and Amazon Bedrock Titan Embed v2 for embeddings.
 
 ## Prerequisites
 
@@ -39,8 +39,9 @@ CREATE EXTENSION IF NOT EXISTS vector;
 ## Step 3: Configure environment
 
 ```bash
-export BACKEND=aws
+export BACKEND=postgres
 export DATABASE_URL="postgresql://distill:<your-password>@distill-db.<id>.<region>.rds.amazonaws.com:5432/distill"
+export EMBEDDING_PROVIDER=bedrock
 export AWS_REGION=us-east-1
 ```
 

--- a/docs/how-to/azure-backend.md
+++ b/docs/how-to/azure-backend.md
@@ -4,7 +4,7 @@ title: Azure Backend Setup
 
 # Azure Backend (PostgreSQL + OpenAI)
 
-The Azure backend uses Azure Database for PostgreSQL Flexible Server with pgvector for storage and Azure OpenAI for embeddings. Distillation still runs locally via Ollama — the privacy guarantee is preserved.
+The Azure setup uses Azure Database for PostgreSQL Flexible Server with pgvector for storage and Azure OpenAI for embeddings.
 
 ## Prerequisites
 
@@ -51,8 +51,9 @@ az cognitiveservices account deployment create \
 ## Step 4: Configure environment
 
 ```bash
-export BACKEND=azure
+export BACKEND=postgres
 export DATABASE_URL="postgresql://distill:<your-password>@distill-db.postgres.database.azure.com:5432/distill?sslmode=require"
+export EMBEDDING_PROVIDER=azure
 export AZURE_OPENAI_ENDPOINT="https://distill-openai.openai.azure.com/"
 export AZURE_OPENAI_API_KEY="<your-api-key>"
 ```

--- a/docs/how-to/gcp-backend.md
+++ b/docs/how-to/gcp-backend.md
@@ -4,7 +4,7 @@ title: GCP Backend Setup
 
 # GCP Backend Setup
 
-The GCP backend uses Cloud SQL (PostgreSQL + pgvector) for storage and Vertex AI for embeddings. Distillation still runs locally via Ollama — the privacy guarantee is preserved.
+The GCP setup uses Cloud SQL (PostgreSQL + pgvector) for storage and Vertex AI for embeddings.
 
 ## Prerequisites
 
@@ -42,9 +42,9 @@ chmod +x cloud-sql-proxy
 ## Step 4: Configure environment
 
 ```bash
-export BACKEND=gcp
-export DB_HOST=127.0.0.1        # via Cloud SQL Proxy
-export DB_NAME=distill
+export BACKEND=postgres
+export DATABASE_URL="postgresql://postgres:password@127.0.0.1:5432/distill"
+export EMBEDDING_PROVIDER=vertex
 export GCP_PROJECT=your-project
 export GCP_LOCATION=us-central1
 ```

--- a/docs/how-to/gemini-backend.md
+++ b/docs/how-to/gemini-backend.md
@@ -1,0 +1,81 @@
+---
+title: Gemini Backend Setup
+---
+
+# Gemini (Free Cloud LLM + Embeddings)
+
+Use Google Gemini as a drop-in replacement for local Ollama. No GPU required, no Ollama process to manage. Works with the free tier.
+
+## When to use this
+
+- You don't have a GPU (or it's busy with other work)
+- You want zero local compute overhead
+- The privacy tradeoff is acceptable — raw text goes to Google for distillation
+
+## Prerequisites
+
+- A Google account
+- A Gemini API key ([get one free at AI Studio](https://aistudio.google.com/apikey))
+
+## Setup
+
+```bash
+EMBEDDING_PROVIDER=gemini
+DISTILLER_PROVIDER=gemini
+GEMINI_API_KEY=your-key-here
+```
+
+Storage stays local (SQLite + LanceDB). Ollama is no longer needed.
+
+## What changes
+
+| Component | Ollama (default) | Gemini |
+|-----------|-----------------|--------|
+| Embeddings | `nomic-embed-text` (local) | `text-embedding-004` (768-dim, Google API) |
+| Distillation | `gemma3:4b` (local) | `gemini-2.0-flash` (Google API) |
+| Storage | unchanged | unchanged |
+| Privacy | Raw text stays on device | Raw text goes to Google |
+| Cost | $0 (needs Ollama running) | $0 (free tier) |
+
+## Optional: customize models
+
+```bash
+EMBEDDING_MODEL=text-embedding-004    # default for gemini provider
+LLM_MODEL=gemini-2.0-flash           # default for gemini provider
+```
+
+`EMBEDDING_MODEL` and `LLM_MODEL` are universal — they apply to whichever provider is active. Each provider has sensible defaults if you omit them.
+
+## Mix and match
+
+Embedding and distillation providers are independent. You can use Gemini for one and Ollama for the other:
+
+```bash
+# Gemini embeddings + local Ollama distillation (privacy-preserving)
+EMBEDDING_PROVIDER=gemini
+DISTILLER_PROVIDER=ollama
+GEMINI_API_KEY=your-key-here
+```
+
+Or combine with PostgreSQL storage:
+
+```bash
+BACKEND=postgres
+DATABASE_URL=postgresql://...
+EMBEDDING_PROVIDER=gemini
+DISTILLER_PROVIDER=gemini
+GEMINI_API_KEY=your-key-here
+```
+
+## Free tier limits
+
+As of March 2026, the Gemini free tier provides:
+
+- **gemini-2.0-flash**: 15 requests/minute, 1M tokens/day
+- **text-embedding-004**: 1500 requests/minute
+
+For typical team memory usage (a few `remember` + `search` calls per minute), the free tier is more than sufficient.
+
+## Switching back to Ollama
+
+Set providers back to `ollama` (or remove `EMBEDDING_PROVIDER` / `DISTILLER_PROVIDER` — Ollama is the default).

--- a/docs/how-to/neon-backend.md
+++ b/docs/how-to/neon-backend.md
@@ -28,11 +28,9 @@ CREATE EXTENSION IF NOT EXISTS vector;
 ## Step 3: Configure environment
 
 ```bash
-export BACKEND=gcp
+export BACKEND=postgres
 export DATABASE_URL="postgresql://user:pass@ep-xyz.us-east-2.aws.neon.tech/distill?sslmode=require"
 ```
-
-`BACKEND=gcp` selects the PostgreSQL adapter — it works with any PostgreSQL provider, not just GCP.
 
 ## Step 4: Start Distill
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,25 +4,76 @@ title: Configuration
 
 # Configuration Reference
 
-All settings are controlled via environment variables (or a `.env` file). Defaults are shown below.
+All settings are controlled via environment variables (or a `.env` file).
 
-## Core settings
+## Storage
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BACKEND` | `local` | Backend type: `local`, `gcp`, `postgres`, `aws`, `azure` |
+| `BACKEND` | `local` | Storage backend: `local` (SQLite + LanceDB) or `postgres` (PostgreSQL + pgvector) |
 | `DATA_DIR` | `~/.team-memory` | Local data directory (SQLite, LanceDB, private store) |
+| `DATABASE_URL` | — | PostgreSQL connection string (required when `BACKEND=postgres`) |
 | `LOG_LEVEL` | `INFO` | Logging level |
 
-## Ollama settings
+## Embedding provider
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EMBEDDING_PROVIDER` | `ollama` | Provider: `ollama`, `gemini`, `vertex`, `bedrock`, `azure` |
+| `EMBEDDING_MODEL` | *(per provider)* | Embedding model name. Defaults: ollama=`nomic-embed-text`, gemini=`text-embedding-004`, vertex=`text-embedding-005`, bedrock=`amazon.titan-embed-text-v2:0`, azure=`text-embedding-3-small` |
+
+All embeddings must produce **768-dimensional** vectors.
+
+## Distillation provider
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DISTILLER_PROVIDER` | `ollama` | Provider: `ollama`, `gemini` |
+| `LLM_MODEL` | *(per provider)* | Distillation model name. Defaults: ollama=`gemma3:4b`, gemini=`gemini-2.0-flash` |
+
+!!! warning "Privacy tradeoff"
+    With `DISTILLER_PROVIDER=gemini`, raw text is sent to Google's API for distillation. With `ollama`, raw text stays on your device.
+
+## Provider credentials
+
+### Ollama (default, no credentials)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API endpoint |
-| `LLM_MODEL` | `gemma3:4b` | Model for distillation |
-| `EMBEDDING_MODEL` | `nomic-embed-text` | Model for embeddings (must produce 768-dim vectors) |
 
-Ollama also reads its own environment variables for GPU control (`OLLAMA_NUM_GPU`, `CUDA_VISIBLE_DEVICES`, etc.). See the [GPU Setup guide](../how-to/gpu-setup.md) for hardware-specific configuration.
+Ollama also reads its own environment variables for GPU control (`OLLAMA_NUM_GPU`, `CUDA_VISIBLE_DEVICES`, etc.). See the [GPU Setup guide](../how-to/gpu-setup.md).
+
+### Gemini
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GEMINI_API_KEY` | — | Required when `EMBEDDING_PROVIDER=gemini` or `DISTILLER_PROVIDER=gemini` |
+
+Free tier available at [AI Studio](https://aistudio.google.com/apikey). See [Gemini Backend](../how-to/gemini-backend.md).
+
+### Vertex AI
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GCP_PROJECT` | — | GCP project ID (required when `EMBEDDING_PROVIDER=vertex`) |
+| `GCP_LOCATION` | `us-central1` | GCP region |
+| `CLOUD_SQL_CONNECTION` | — | Cloud SQL instance connection name |
+
+### Bedrock
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AWS_REGION` | `us-east-1` | AWS region |
+
+Uses the default AWS credential chain (environment variables, `~/.aws/credentials`, or instance role).
+
+### Azure OpenAI
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AZURE_OPENAI_ENDPOINT` | — | Endpoint URL (required when `EMBEDDING_PROVIDER=azure`) |
+| `AZURE_OPENAI_API_KEY` | — | API key (required when `EMBEDDING_PROVIDER=azure`) |
 
 ## Privacy & review
 
@@ -42,9 +93,7 @@ Ollama also reads its own environment variables for GPU control (`OLLAMA_NUM_GPU
 | `MAX_MEMORY_SIZE` | `8000` | Maximum memory content size in characters |
 | `FTS_LANGUAGE` | `simple` | Full-text search language configuration |
 
-## Reranking (optional, GCP-only)
-
-Cross-encoder reranking improves search relevance by re-scoring results after hybrid search.
+## Reranking (optional)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -52,46 +101,12 @@ Cross-encoder reranking improves search relevance by re-scoring results after hy
 | `JINA_API_KEY` | — | Jina Reranker API key |
 | `RERANK_MODEL` | `jina-reranker-v2-base-multilingual` | Reranker model |
 
-Reranking adds latency (~200ms) and requires an external API call. Only recommended for GCP backend where search quality is critical. The privacy constraint is preserved — only distilled content (never raw input) is sent to the reranker.
-
-## PostgreSQL settings
-
-Used when `BACKEND=gcp`. Works with any PostgreSQL provider that supports pgvector (Cloud SQL, [Neon](../how-to/neon-backend.md), Supabase, self-hosted).
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DATABASE_URL` | — | PostgreSQL connection string |
-| `GCP_PROJECT` | — | GCP project ID (Cloud SQL / Vertex AI only) |
-| `GCP_LOCATION` | `us-central1` | GCP region for Vertex AI |
-| `CLOUD_SQL_CONNECTION` | — | Cloud SQL instance connection name |
-
-## AWS settings
-
-Used when `BACKEND=aws`. Uses Amazon Bedrock for embeddings.
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AWS_REGION` | `us-east-1` | AWS region for Bedrock |
-| `AWS_BEDROCK_MODEL` | `amazon.titan-embed-text-v2:0` | Bedrock embedding model |
-
-## Azure settings
-
-Used when `BACKEND=azure`. Uses Azure OpenAI for embeddings.
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AZURE_OPENAI_ENDPOINT` | — | Azure OpenAI endpoint URL (required when `BACKEND=azure`) |
-| `AZURE_OPENAI_API_KEY` | — | Azure OpenAI API key (required when `BACKEND=azure`) |
-| `AZURE_OPENAI_DEPLOYMENT` | `text-embedding-3-small` | Azure OpenAI deployment name |
-
 ## Port interfaces
 
-Distill uses Clean Architecture ports. Each setting selects an adapter:
-
-| Port | `local` adapter | `gcp` adapter | `aws` adapter | `azure` adapter |
-|------|----------------|---------------|---------------|-----------------|
-| `StoragePort` | SQLite + FTS5 + LanceDB | Cloud SQL + pgvector + tsvector | Cloud SQL + pgvector + tsvector | Cloud SQL + pgvector + tsvector |
-| `EmbeddingPort` | Ollama (`nomic-embed-text`) | Vertex AI (`text-embedding-005`) | Bedrock (`amazon.titan-embed-text-v2:0`) | Azure OpenAI (`text-embedding-3-small`) |
-| `DistillerPort` | Ollama (`gemma3:4b`) | Ollama (`gemma3:4b`) — always local | Ollama (`gemma3:4b`) — always local | Ollama (`gemma3:4b`) — always local |
-| `ScannerPort` | gitleaks-based secret detection | gitleaks-based secret detection | gitleaks-based secret detection | gitleaks-based secret detection |
-| `RerankerPort` | — (not used) | Jina Reranker API (opt-in) | — (not used) | — (not used) |
+| Port | Adapters |
+|------|----------|
+| `StoragePort` | `local`: SQLite + FTS5 + LanceDB | `postgres`: PostgreSQL + pgvector + tsvector |
+| `EmbeddingPort` | `ollama` `gemini` `vertex` `bedrock` `azure` — selected by `EMBEDDING_PROVIDER` |
+| `DistillerPort` | `ollama` `gemini` — selected by `DISTILLER_PROVIDER` |
+| `ScannerPort` | secrets + PII detection (always active) |
+| `RerankerPort` | Jina Reranker API (opt-in via `RERANK_ENABLED`) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - Neon Backend: how-to/neon-backend.md
     - AWS Backend: how-to/aws-backend.md
     - Azure Backend: how-to/azure-backend.md
+    - Gemini Backend: how-to/gemini-backend.md
   - Reference:
     - MCP Tools: reference/tools.md
     - Configuration: reference/configuration.md

--- a/src/distill_mcp/CLAUDE.md
+++ b/src/distill_mcp/CLAUDE.md
@@ -40,12 +40,13 @@ def remember(content: str, type: str, repos: list[str], tags: list[str] | None =
 | `list_recent` | Filter by repo/tag/type | R |
 | `forget` | Soft-delete | W |
 
-## Two backends
+## Three independent axes
 
-- `BACKEND=local` — SQLite + FTS5 + LanceDB. Ollama for everything. $0.
-- `BACKEND=gcp` — Cloud SQL PostgreSQL + pgvector. Vertex AI for embeddings only. Distillation still local Ollama. ~$11/mo.
+- `BACKEND` — storage: `local` (SQLite + LanceDB) or `postgres` (PostgreSQL + pgvector)
+- `EMBEDDING_PROVIDER` — embeddings: `ollama` | `gemini` | `vertex` | `bedrock` | `azure`
+- `DISTILLER_PROVIDER` — distillation: `ollama` | `gemini`
 
-Backend is selected in `__main__.py` via config, injected into services as ports.
+All three are selected in `__main__.py` via config, injected into services as ports.
 
 ## Code style
 

--- a/src/distill_mcp/__main__.py
+++ b/src/distill_mcp/__main__.py
@@ -17,20 +17,8 @@ def _init_store() -> tuple:
 
         identity = resolve_git_identity()
 
-    if settings.backend in ("gcp", "postgres", "aws", "azure"):
+    if settings.backend == "postgres":
         from distill_mcp.adapters.storage.postgres_store import PostgresStore
-
-        if settings.backend == "gcp" and not settings.gcp_project:
-            raise RuntimeError("GCP_PROJECT is required when BACKEND=gcp")
-        if settings.backend == "azure":
-            if not settings.azure_openai_endpoint:
-                raise RuntimeError(
-                    "AZURE_OPENAI_ENDPOINT is required when BACKEND=azure"
-                )
-            if not settings.azure_openai_api_key:
-                raise RuntimeError(
-                    "AZURE_OPENAI_API_KEY is required when BACKEND=azure"
-                )
 
         store = PostgresStore(dsn=settings.database_url, identity=identity)
         return store, True, identity
@@ -45,7 +33,6 @@ def _run_server() -> None:
     import asyncio
     from pathlib import Path
 
-    from distill_mcp.adapters.distiller.ollama_distill import OllamaDistiller
     from distill_mcp.adapters.scanner.secret_scanner import SecretScanner
     from distill_mcp.domain.services import MemoryService
     from distill_mcp.server import mcp, set_service
@@ -57,37 +44,88 @@ def _run_server() -> None:
     else:
         store.initialize()
 
-    if settings.backend == "gcp":
+    # Provider defaults — used when EMBEDDING_MODEL / LLM_MODEL not set
+    _embedding_defaults = {
+        "ollama": "nomic-embed-text",
+        "gemini": "text-embedding-004",
+        "vertex": "text-embedding-005",
+        "bedrock": "amazon.titan-embed-text-v2:0",
+        "azure": "text-embedding-3-small",
+    }
+    _llm_defaults = {
+        "ollama": "gemma3:4b",
+        "gemini": "gemini-2.0-flash",
+    }
+
+    ep = settings.embedding_provider
+    dp = settings.distiller_provider
+    embedding_model = settings.embedding_model or _embedding_defaults.get(
+        ep, "nomic-embed-text"
+    )
+    llm_model = settings.llm_model or _llm_defaults.get(dp, "gemma3:4b")
+
+    # Embedding provider
+    if ep == "gemini":
+        from distill_mcp.adapters.embeddings.gemini_embed import GeminiEmbedder
+
+        if not settings.gemini_api_key:
+            raise RuntimeError(
+                "GEMINI_API_KEY is required when EMBEDDING_PROVIDER=gemini"
+            )
+        embedder = GeminiEmbedder(
+            api_key=settings.gemini_api_key,
+            model=embedding_model,
+        )
+    elif ep == "vertex":
         from distill_mcp.adapters.embeddings.vertex_embed import VertexEmbedder
 
+        if not settings.gcp_project:
+            raise RuntimeError("GCP_PROJECT is required when EMBEDDING_PROVIDER=vertex")
         embedder = VertexEmbedder(
-            project=settings.gcp_project or "",
+            project=settings.gcp_project,
             location=settings.gcp_location,
         )
-    elif settings.backend == "aws":
+    elif ep == "bedrock":
         from distill_mcp.adapters.embeddings.bedrock_embed import BedrockEmbedder
 
         embedder = BedrockEmbedder(
             region=settings.aws_region,
-            model=settings.aws_bedrock_model,
+            model=embedding_model,
         )
-    elif settings.backend == "azure":
+    elif ep == "azure":
         from distill_mcp.adapters.embeddings.azure_embed import AzureOpenAIEmbedder
 
+        if not settings.azure_openai_endpoint or not settings.azure_openai_api_key:
+            raise RuntimeError(
+                "AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_API_KEY are required "
+                "when EMBEDDING_PROVIDER=azure"
+            )
         embedder = AzureOpenAIEmbedder(
-            endpoint=settings.azure_openai_endpoint or "",
-            api_key=settings.azure_openai_api_key or "",
-            deployment=settings.azure_openai_deployment,
+            endpoint=settings.azure_openai_endpoint,
+            api_key=settings.azure_openai_api_key,
+            deployment=embedding_model,
         )
     else:
         from distill_mcp.adapters.embeddings.ollama_embed import OllamaEmbedder
 
-        embedder = OllamaEmbedder(
-            host=settings.ollama_host, model=settings.embedding_model
-        )
+        embedder = OllamaEmbedder(host=settings.ollama_host, model=embedding_model)
 
-    # Distiller stays local Ollama regardless of backend (privacy constraint)
-    distiller = OllamaDistiller(host=settings.ollama_host, model=settings.llm_model)
+    # Distillation provider
+    if dp == "gemini":
+        from distill_mcp.adapters.distiller.gemini_distill import GeminiDistiller
+
+        if not settings.gemini_api_key:
+            raise RuntimeError(
+                "GEMINI_API_KEY is required when DISTILLER_PROVIDER=gemini"
+            )
+        distiller = GeminiDistiller(
+            api_key=settings.gemini_api_key,
+            model=llm_model,
+        )
+    else:
+        from distill_mcp.adapters.distiller.ollama_distill import OllamaDistiller
+
+        distiller = OllamaDistiller(host=settings.ollama_host, model=llm_model)
 
     private_dir = Path(settings.data_dir).expanduser() / "private"
 

--- a/src/distill_mcp/adapters/CLAUDE.md
+++ b/src/distill_mcp/adapters/CLAUDE.md
@@ -1,8 +1,8 @@
 # Adapters — implementations of domain ports
 
-## Distillation rules (distiller/ollama_distill.py)
+## Distillation rules (distiller/ollama_distill.py, distiller/gemini_distill.py)
 
-The distillation prompt must:
+The distillation prompt (shared by both providers) must:
 - Remove all first-person language (I, we, my)
 - Remove all names of people
 - Remove emotional language, blame, frustration
@@ -11,9 +11,10 @@ The distillation prompt must:
 - Output: 1-3 sentences of pure factual knowledge
 - Never add information not in the input
 
-## Privacy constraints — non-negotiable
+## Privacy constraints
 
-- Raw text NEVER goes to any cloud service. Only to localhost Ollama.
+- `DISTILLER_PROVIDER=ollama` (default): raw text goes only to localhost Ollama.
+- `DISTILLER_PROVIDER=gemini`: raw text goes to Google Gemini — user opt-in.
 - `AUTHOR_MODE` env var: `anonymous` (default) | `pseudonym` | `named`. Developer's local choice.
 - `REVIEW_BEFORE_SAVE=true` by default. Developer approves distilled output before storing.
 - Anthropic only sees distilled search results via Claude Code context window.

--- a/src/distill_mcp/adapters/distiller/gemini_distill.py
+++ b/src/distill_mcp/adapters/distiller/gemini_distill.py
@@ -1,0 +1,61 @@
+"""DistillerPort implementation — Google Gemini API (cloud)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+
+from distill_mcp.adapters.distiller.ollama_distill import DISTILL_SYSTEM, DISTILL_USER
+
+API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+
+class GeminiDistiller:
+    """Distills raw text via Google Gemini API. Implements DistillerPort."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gemini-2.0-flash",
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+
+    async def distill(self, raw_text: str) -> str:
+        prompt = DISTILL_USER.format(
+            today=date.today().isoformat(),
+            raw_text=raw_text,
+        )
+        url = f"{API_BASE}/models/{self._model}:generateContent?key={self._api_key}"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    url,
+                    json={
+                        "systemInstruction": {
+                            "parts": [{"text": DISTILL_SYSTEM}],
+                        },
+                        "contents": [
+                            {"role": "user", "parts": [{"text": prompt}]},
+                        ],
+                    },
+                    timeout=60.0,
+                )
+                resp.raise_for_status()
+                result = resp.json()["candidates"][0]["content"]["parts"][0][
+                    "text"
+                ].strip()
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Gemini distillation failed: HTTP {e.response.status_code}"
+            ) from e
+        except httpx.ConnectError:
+            raise RuntimeError(
+                "Gemini API is not reachable at generativelanguage.googleapis.com"
+            ) from None
+        except (httpx.TimeoutException, httpx.RequestError) as e:
+            raise RuntimeError(f"Gemini distillation request failed: {e}") from e
+        except (KeyError, IndexError) as e:
+            raise RuntimeError(f"Unexpected Gemini response format: {e}") from e
+        return result

--- a/src/distill_mcp/adapters/embeddings/gemini_embed.py
+++ b/src/distill_mcp/adapters/embeddings/gemini_embed.py
@@ -1,0 +1,48 @@
+"""EmbeddingPort implementation — Google Gemini API text embeddings."""
+
+from __future__ import annotations
+
+import httpx
+
+API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+
+class GeminiEmbedder:
+    """Embeds text via Google Gemini API. Implements EmbeddingPort."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "text-embedding-004",
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+
+    async def embed(self, text: str) -> list[float]:
+        url = f"{API_BASE}/models/{self._model}:embedContent?key={self._api_key}"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    url,
+                    json={
+                        "model": f"models/{self._model}",
+                        "content": {"parts": [{"text": text}]},
+                    },
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+                return resp.json()["embedding"]["values"]
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Gemini embedding failed: HTTP {e.response.status_code}"
+            ) from e
+        except httpx.ConnectError:
+            raise RuntimeError(
+                "Gemini API is not reachable at generativelanguage.googleapis.com"
+            ) from None
+        except (httpx.TimeoutException, httpx.RequestError) as e:
+            raise RuntimeError(f"Gemini embedding request failed: {e}") from e
+        except (KeyError, IndexError) as e:
+            raise RuntimeError(
+                f"Unexpected Gemini embedding response format: {e}"
+            ) from e

--- a/src/distill_mcp/settings.py
+++ b/src/distill_mcp/settings.py
@@ -6,14 +6,40 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
-    backend: str = "local"
+    # Storage backend
+    backend: str = "local"  # local | postgres
     database_url: str | None = (
         None  # e.g. postgresql://user:pass@localhost:5432/distill
     )
     data_dir: str = "~/.team-memory"
+
+    # Embedding provider
+    embedding_provider: str = "ollama"  # ollama | gemini | vertex | bedrock | azure
+    embedding_model: str | None = None  # default per provider (see __main__.py)
+
+    # Distillation provider
+    distiller_provider: str = "ollama"  # ollama | gemini
+    llm_model: str | None = None  # default per provider (see __main__.py)
+
+    # Ollama (used when embedding_provider=ollama or distiller_provider=ollama)
     ollama_host: str = "http://localhost:11434"
-    embedding_model: str = "nomic-embed-text"
-    llm_model: str = "gemma3:4b"
+
+    # Gemini (used when embedding_provider=gemini or distiller_provider=gemini)
+    gemini_api_key: str | None = None
+
+    # Vertex AI (used when embedding_provider=vertex)
+    gcp_project: str | None = None
+    gcp_location: str = "us-central1"
+    cloud_sql_connection: str | None = None
+
+    # Bedrock (used when embedding_provider=bedrock)
+    aws_region: str = "us-east-1"
+
+    # Azure OpenAI (used when embedding_provider=azure)
+    azure_openai_endpoint: str | None = None
+    azure_openai_api_key: str | None = None
+
+    # General
     default_author: str = "unknown"
     rrf_k: int = 60
     max_memory_size: int = 8000
@@ -26,20 +52,6 @@ class Settings(BaseSettings):
     rerank_enabled: bool = False
     jina_api_key: str | None = None
     rerank_model: str = "jina-reranker-v2-base-multilingual"
-
-    # GCP settings (only used when backend=gcp)
-    gcp_project: str | None = None
-    gcp_location: str = "us-central1"
-    cloud_sql_connection: str | None = None
-
-    # AWS settings (only used when backend=aws)
-    aws_region: str = "us-east-1"
-    aws_bedrock_model: str = "amazon.titan-embed-text-v2:0"
-
-    # Azure settings (only used when backend=azure)
-    azure_openai_endpoint: str | None = None
-    azure_openai_api_key: str | None = None
-    azure_openai_deployment: str = "text-embedding-3-small"
 
 
 settings = Settings()

--- a/tests/test_gemini_distill.py
+++ b/tests/test_gemini_distill.py
@@ -1,0 +1,164 @@
+"""Unit tests for the Gemini distiller adapter.
+
+All network calls are mocked — no API key required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from distill_mcp.adapters.distiller.gemini_distill import GeminiDistiller
+
+pytestmark = pytest.mark.asyncio
+
+
+# -- Construction --
+
+
+def test_default_model() -> None:
+    d = GeminiDistiller(api_key="test-key")
+    assert d._model == "gemini-2.0-flash"
+
+
+def test_custom_model() -> None:
+    d = GeminiDistiller(api_key="test-key", model="gemini-2.0-flash-lite")
+    assert d._model == "gemini-2.0-flash-lite"
+
+
+# -- Helpers --
+
+
+def _mock_async_client(*, post_return=None, post_side_effect=None) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    if post_side_effect is not None:
+        mock_client.post = AsyncMock(side_effect=post_side_effect)
+    else:
+        mock_client.post = AsyncMock(return_value=post_return)
+    return mock_client
+
+
+def _gemini_response(text: str) -> dict:
+    return {"candidates": [{"content": {"parts": [{"text": text}], "role": "model"}}]}
+
+
+# -- Happy path --
+
+
+async def test_distill_returns_text() -> None:
+    distiller = GeminiDistiller(api_key="test-key")
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = _gemini_response(
+        "PostgreSQL was migrated to version 16 in 2026-03."
+    )
+
+    mock_client = _mock_async_client(post_return=mock_resp)
+
+    with patch(
+        "distill_mcp.adapters.distiller.gemini_distill.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        result = await distiller.distill("I upgraded postgres to 16 yesterday")
+
+    assert "PostgreSQL" in result
+    assert "version 16" in result
+
+    call_args = mock_client.post.call_args
+    url = call_args[0][0]
+    assert "gemini-2.0-flash" in url
+    assert "key=test-key" in url
+
+    body = call_args[1]["json"]
+    assert "systemInstruction" in body
+    assert body["contents"][0]["role"] == "user"
+
+
+async def test_distill_strips_whitespace() -> None:
+    distiller = GeminiDistiller(api_key="test-key")
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = _gemini_response("  result with spaces  \n")
+
+    mock_client = _mock_async_client(post_return=mock_resp)
+
+    with patch(
+        "distill_mcp.adapters.distiller.gemini_distill.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        result = await distiller.distill("test input")
+
+    assert result == "result with spaces"
+
+
+# -- HTTP errors --
+
+
+async def test_http_error_raises_runtime_error() -> None:
+    distiller = GeminiDistiller(api_key="test-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+
+    mock_client = _mock_async_client(
+        post_side_effect=httpx.HTTPStatusError(
+            "Rate limited", request=MagicMock(), response=mock_response
+        )
+    )
+
+    with patch(
+        "distill_mcp.adapters.distiller.gemini_distill.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Gemini distillation failed: HTTP 429"):
+            await distiller.distill("test")
+
+
+async def test_connect_error_raises_runtime_error() -> None:
+    distiller = GeminiDistiller(api_key="test-key")
+    mock_client = _mock_async_client(post_side_effect=httpx.ConnectError("refused"))
+
+    with patch(
+        "distill_mcp.adapters.distiller.gemini_distill.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Gemini API is not reachable"):
+            await distiller.distill("test")
+
+
+async def test_timeout_raises_runtime_error() -> None:
+    distiller = GeminiDistiller(api_key="test-key")
+    mock_client = _mock_async_client(post_side_effect=httpx.ReadTimeout("timed out"))
+
+    with patch(
+        "distill_mcp.adapters.distiller.gemini_distill.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Gemini distillation request failed"):
+            await distiller.distill("test")
+
+
+# -- Malformed response --
+
+
+async def test_malformed_response_raises_runtime_error() -> None:
+    distiller = GeminiDistiller(api_key="test-key")
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"candidates": []}
+
+    mock_client = _mock_async_client(post_return=mock_resp)
+
+    with patch(
+        "distill_mcp.adapters.distiller.gemini_distill.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Unexpected Gemini response"):
+            await distiller.distill("test")

--- a/tests/test_gemini_embed.py
+++ b/tests/test_gemini_embed.py
@@ -1,0 +1,139 @@
+"""Unit tests for the Gemini embedding adapter.
+
+All network calls are mocked — no API key required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from distill_mcp.adapters.embeddings.gemini_embed import GeminiEmbedder
+
+pytestmark = pytest.mark.asyncio
+
+
+# -- Construction --
+
+
+def test_default_model() -> None:
+    e = GeminiEmbedder(api_key="test-key")
+    assert e._model == "text-embedding-004"
+
+
+def test_custom_model() -> None:
+    e = GeminiEmbedder(api_key="test-key", model="custom-embed")
+    assert e._model == "custom-embed"
+
+
+# -- Helpers --
+
+
+def _mock_async_client(*, post_return=None, post_side_effect=None) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    if post_side_effect is not None:
+        mock_client.post = AsyncMock(side_effect=post_side_effect)
+    else:
+        mock_client.post = AsyncMock(return_value=post_return)
+    return mock_client
+
+
+# -- Happy path --
+
+
+async def test_embed_returns_vector() -> None:
+    embedder = GeminiEmbedder(api_key="test-key")
+    fake_vec = [0.1] * 768
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"embedding": {"values": fake_vec}}
+
+    mock_client = _mock_async_client(post_return=mock_resp)
+
+    with patch(
+        "distill_mcp.adapters.embeddings.gemini_embed.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        result = await embedder.embed("hello world")
+
+    assert result == fake_vec
+
+    call_args = mock_client.post.call_args
+    url = call_args[0][0]
+    assert "text-embedding-004" in url
+    assert "key=test-key" in url
+
+    body = call_args[1]["json"]
+    assert body["content"]["parts"][0]["text"] == "hello world"
+
+
+# -- HTTP errors --
+
+
+async def test_http_error_raises_runtime_error() -> None:
+    embedder = GeminiEmbedder(api_key="test-key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+
+    mock_client = _mock_async_client(
+        post_side_effect=httpx.HTTPStatusError(
+            "Forbidden", request=MagicMock(), response=mock_response
+        )
+    )
+
+    with patch(
+        "distill_mcp.adapters.embeddings.gemini_embed.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Gemini embedding failed: HTTP 403"):
+            await embedder.embed("test")
+
+
+async def test_connect_error_raises_runtime_error() -> None:
+    embedder = GeminiEmbedder(api_key="test-key")
+    mock_client = _mock_async_client(post_side_effect=httpx.ConnectError("refused"))
+
+    with patch(
+        "distill_mcp.adapters.embeddings.gemini_embed.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Gemini API is not reachable"):
+            await embedder.embed("test")
+
+
+async def test_timeout_raises_runtime_error() -> None:
+    embedder = GeminiEmbedder(api_key="test-key")
+    mock_client = _mock_async_client(post_side_effect=httpx.ReadTimeout("timed out"))
+
+    with patch(
+        "distill_mcp.adapters.embeddings.gemini_embed.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Gemini embedding request failed"):
+            await embedder.embed("test")
+
+
+# -- Malformed response --
+
+
+async def test_malformed_response_raises_runtime_error() -> None:
+    embedder = GeminiEmbedder(api_key="test-key")
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"wrong": "format"}
+
+    mock_client = _mock_async_client(post_return=mock_resp)
+
+    with patch(
+        "distill_mcp.adapters.embeddings.gemini_embed.httpx.AsyncClient"
+    ) as mock_cls:
+        mock_cls.return_value = mock_client
+        with pytest.raises(RuntimeError, match="Unexpected Gemini embedding response"):
+            await embedder.embed("test")


### PR DESCRIPTION
## Summary

- Adds Google Gemini as embedding and distillation provider (free tier, no GPU needed)
- Decouples configuration into three independent axes: `BACKEND` (storage), `EMBEDDING_PROVIDER`, `DISTILLER_PROVIDER`
- Removes overloaded `BACKEND=gcp/aws/azure` — storage is now always `local` or `postgres`, providers are selected separately

## Changes

**New adapters:**
- `gemini_embed.py` — Gemini API embeddings (`text-embedding-004`, 768-dim)
- `gemini_distill.py` — Gemini API distillation (reuses existing privacy prompt)

**Refactored config:**
- `settings.py` — `EMBEDDING_PROVIDER` and `DISTILLER_PROVIDER` replace implicit backend-coupled selection
- `__main__.py` — clean provider dispatch with per-provider model defaults
- Removed `aws_bedrock_model`, `azure_openai_deployment`, `gemini_embedding_model`, `gemini_llm_model` — unified under `EMBEDDING_MODEL` / `LLM_MODEL`

**Docs:** Updated all CLAUDE.md files, configuration reference, architecture, privacy model, all backend how-to guides, new gemini-backend.md

## Test plan

- [x] 15 new tests for Gemini adapters (7 embed + 8 distill)
- [x] Full suite: 236 passed, 0 failed
- [x] All pre-commit hooks pass (ruff, ty, gitleaks)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)