### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distill-mcp"
-version = "0.1.2"
+version = "0.2.0"
 description = "Privacy-first team memory MCP server — local LLM distillation before team sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/distill_mcp/__init__.py
+++ b/src/distill_mcp/__init__.py
@@ -1,3 +1,3 @@
 """team-memory-mcp — privacy-first team memory MCP server."""
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "distill-mcp"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "detect-secrets" },


### PR DESCRIPTION
## Summary
- Bumps version from 0.1.2 to 0.2.0 across `pyproject.toml` and `__init__.py` (were out of sync at 0.1.2/0.1.1)
- Triggers CI/CD PyPI publish for new features: Gemini provider, memory levels, stale detection, export command

## Changes
- `pyproject.toml`: 0.1.2 → 0.2.0
- `src/distill_mcp/__init__.py`: 0.1.1 → 0.2.0
- `uv.lock`: auto-updated

## Test plan
- [x] 237 tests pass
- [x] All pre-commit hooks pass