### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "distill-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Privacy-first team memory MCP server — local LLM distillation before team sync"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/distill_mcp/__init__.py
+++ b/src/distill_mcp/__init__.py
@@ -1,3 +1,3 @@
 """team-memory-mcp — privacy-first team memory MCP server."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "distill-mcp"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bump version `0.2.0` → `0.3.0` in `pyproject.toml`, `__init__.py`, and `uv.lock` following the auto-observe pipeline merge (#80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)