### PR TITLE
feat: Add /release skill for PyPI publishing

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -4,21 +4,54 @@ Bump version, tag, and publish to PyPI via the existing GitHub Actions workflow.
 
 ## Arguments
 
-`<version>` — the version to release (e.g. `0.4.0`). Required.
+- `<version>` — explicit version (e.g. `0.4.0`). Optional.
+- `major` / `minor` / `patch` — bump type. Optional.
+- No argument — auto-detect from conventional commits since last tag.
 
 ## Workflow
 
-### 1. Validate
+### 1. Determine version
+
+If no explicit version given, auto-detect from commit history:
+
+```bash
+# Find last tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+# Get commits since last tag (or all commits if no tag)
+if [ -n "$LAST_TAG" ]; then
+  COMMITS=$(git log "$LAST_TAG"..HEAD --oneline)
+else
+  COMMITS=$(git log --oneline)
+fi
+```
+
+Scan commit messages for the highest bump level:
+
+| Pattern | Bump |
+|---------|------|
+| `feat!:` or `BREAKING CHANGE:` in body | MAJOR |
+| `feat:` or `feat(scope):` | MINOR |
+| `fix:`, `perf:`, `ref:`, `docs:`, `chore:`, `build:`, `ci:`, `test:`, `style:` | PATCH |
+
+Rules:
+- Use the **highest** bump found (MAJOR > MINOR > PATCH)
+- If no conventional commits found, default to PATCH
+- Parse current version from `pyproject.toml`: `grep '^version' pyproject.toml`
+- Calculate new version by incrementing the appropriate component (reset lower components to 0)
+
+Show the user: commit summary, detected bump level, and proposed version. Wait for confirmation before proceeding.
+
+### 2. Validate
 
 - Confirm on `main` branch: `git branch --show-current`
 - Confirm working tree is clean: `git status --short` (ignore `.claude/settings.json`)
-- Confirm the version argument is valid semver (MAJOR.MINOR.PATCH)
 - Confirm the tag `v<version>` does not already exist: `git tag -l v<version>`
 - Confirm CI is green on main: `gh run list --branch main --workflow ci.yml --limit 1 --json conclusion --jq '.[0].conclusion'`
 
 If any check fails, stop and explain why.
 
-### 2. Bump version
+### 3. Bump version
 
 Update the version string in two files:
 
@@ -29,7 +62,7 @@ Update the version string in two files:
 
 Use the Edit tool (not sed) to replace the old version with the new one.
 
-### 3. Commit and tag
+### 4. Commit and tag
 
 ```bash
 git add pyproject.toml src/distill_mcp/__init__.py
@@ -37,14 +70,14 @@ git commit -m "chore: bump version to <version>"
 git tag v<version>
 ```
 
-### 4. Push
+### 5. Push
 
 ```bash
 git push origin main
 git push origin v<version>
 ```
 
-### 5. Create GitHub release
+### 6. Create GitHub release
 
 ```bash
 gh release create v<version> --title "v<version>" --generate-notes
@@ -52,7 +85,7 @@ gh release create v<version> --title "v<version>" --generate-notes
 
 This triggers `.github/workflows/publish.yml` which builds and publishes to PyPI via trusted publishing.
 
-### 6. Verify
+### 7. Verify
 
 Wait for the publish workflow to complete:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Every code change follows this sequence. Do not skip steps.
    Ollama-dependent tests are marked with `@pytest.mark.ollama` and skipped in CI (no Ollama on Ubuntu runners). They run locally only.
 7. **Green gate** — CI must be green before merging. If CI fails: read the logs, fix locally, push again. Repeat until green.
 8. **Merge** — Squash-merge into `main` via GitHub.
-9. **Release** — When ready to publish a new version, run `/release <version>` (e.g. `/release 0.4.0`). This bumps `pyproject.toml` + `__init__.py`, tags, and creates a GitHub release that triggers PyPI publishing.
+9. **Release** — Run `/release` to publish a new version. It auto-detects the bump level (major/minor/patch) from conventional commit prefixes since the last tag, or accepts an explicit version (`/release 0.4.0`). Bumps `pyproject.toml` + `__init__.py`, tags, and creates a GitHub release that triggers PyPI publishing.
 
 ## What NOT to do
 


### PR DESCRIPTION
## Summary

- Adds a `/release <version>` skill that automates the full release flow: bump version in `pyproject.toml` + `__init__.py`, commit, tag, push, create GitHub release (triggers existing `publish.yml` for PyPI)
- References the skill in CLAUDE.md development workflow as step 9

## Changes

- `.claude/skills/release/SKILL.md` — new skill with validation, bump, tag, release, and verify steps
- `CLAUDE.md` — added step 9 to development workflow pointing to `/release`

## Test plan

- [ ] Run `/release 0.4.0` after merging to verify the full flow
- [ ] Verify skill appears in Claude Code skill list

Co-Authored-By: Claude <noreply@anthropic.com>