### PR TITLE
chore: Bump GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync
       - run: uv run ruff check .
       - run: uv run ruff format --check .

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -32,7 +32,7 @@ jobs:
       - name: Build site
         run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: site
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
 
       - run: uv build
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 for GitHub Actions runners, with the enforcement deadline on **June 2, 2026**. After that date, actions using Node.js 20 will stop working.

This PR bumps all GitHub Actions to their latest versions, which use Node.js 24:

- `actions/checkout` v4 → **v6** (latest v6.0.2)
- `astral-sh/setup-uv` v5/v6 → **v7** (latest v7.6.0)
- `actions/setup-python` v5 → **v6** (latest v6.2.0)
- `actions/upload-pages-artifact` v3 → **v4** (latest v4.0.0)
- `pypa/gh-action-pypi-publish` release/v1 → **v1.13.0** (pinned to latest)
- `actions/deploy-pages` v4 stays at **v4** (already latest at v4.0.5)

## Affected workflows

- `.github/workflows/ci.yml`
- `.github/workflows/deploy-docs.yml`
- `.github/workflows/publish.yml`

## Test plan

- [x] CI workflow passes on this PR
- [x] Verify no Node.js deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)