### PR TITLE
docs: update mkdocs for v0.4.0 features

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -16,7 +16,7 @@ graph TB
     end
 
     subgraph "Server Layer"
-        SRV["server.py — 7 MCP tools"]
+        SRV["server.py — 8 MCP tools"]
         ING["ingest.py — HTTP /observe endpoint"]
         WRK["worker.py — background distillation"]
         MAIN["__main__.py — wiring & startup"]
@@ -78,10 +78,14 @@ src/distill_mcp/
 │   ├── embeddings/
 │   │   ├── ollama_embed.py    # EmbeddingPort → local Ollama
 │   │   ├── vertex_embed.py    # EmbeddingPort → Vertex AI
-│   │   └── gemini_embed.py    # EmbeddingPort → Gemini API
+│   │   ├── gemini_embed.py    # EmbeddingPort → Gemini API
+│   │   ├── bedrock_embed.py   # EmbeddingPort → AWS Bedrock
+│   │   └── azure_embed.py     # EmbeddingPort → Azure OpenAI
 │   ├── distiller/
 │   │   ├── ollama_distill.py  # DistillerPort → local Ollama
 │   │   └── gemini_distill.py  # DistillerPort → Gemini API
+│   ├── identity/
+│   │   └── git_identity.py    # Git-based identity resolution (AUTH_ENABLED)
 │   ├── scanner/
 │   │   └── secret_scanner.py  # ScannerPort → secrets + PII redaction
 │   └── reranker/
@@ -90,6 +94,8 @@ src/distill_mcp/
 ├── server.py            # FastMCP tool definitions — thin adapter
 ├── ingest.py            # HTTP /observe endpoint (localhost)
 ├── worker.py            # Background distillation consumer
+├── dedup.py             # Cosine similarity > 0.95 check
+├── hardware.py          # GPU/hardware detection for check-hardware CLI
 ├── settings.py          # pydantic-settings, env var loading
 └── __main__.py          # Entry point: wires adapters, starts FastMCP + ingest + worker
 ```

--- a/docs/explanation/how-memory-works.md
+++ b/docs/explanation/how-memory-works.md
@@ -268,11 +268,39 @@ Since observations are captured automatically, contradiction resolution happens 
 
 The old memory stops appearing in search results, but the chain of supersession is preserved in the database. This means you can always trace how knowledge evolved.
 
+## Lineage tracking
+
+When a memory is updated via `update_memory`, the new memory records a `supersedes` link to the old one. The `get_lineage` tool traces this chain in both directions — predecessors (what this memory replaced) and successors (what replaced this memory) — ordered oldest to newest.
+
+This lets you understand how a decision evolved:
+
+```
+v1: "Redis chosen for caching"
+  └── superseded by v2: "Redis chosen for caching and session storage"
+       └── superseded by v3: "Switched from Redis to Valkey for caching and sessions"
+```
+
+Call `get_lineage(id)` with any memory in the chain to see the full history.
+
+## Temporal search
+
+`search_memory` supports `after` and `before` parameters (ISO 8601 date strings) to restrict results to a specific time window. This is useful for questions like:
+
+- "What decisions did we make last week?" → `after="2026-03-15"`
+- "What did we know before the migration?" → `before="2026-03-01"`
+- "What changed in February?" → `after="2026-02-01"`, `before="2026-03-01"`
+
+Temporal filters are applied after the hybrid search pipeline, so they work with all other search features (FTS, vector similarity, reranking).
+
 ## Forgetting
 
-`forget` is a soft delete — it sets `deleted_at` on the memory, which excludes it from all search results. The data isn't physically removed from the database.
+`forget` is a soft delete — it sets `deleted_at` on the memory, which excludes it from all search results. The data isn't physically removed from the database immediately.
 
 When `agent_id` is provided, forget only works if the memory belongs to that agent. This prevents one agent from accidentally deleting another agent's knowledge.
+
+### Retention purge
+
+Soft-deleted memories are hard-deleted after `RETENTION_DAYS` (default: 90 days). This runs automatically on server startup. Set `RETENTION_DAYS=0` to disable automatic purging and keep soft-deleted memories indefinitely.
 
 ## Stale memory detection
 

--- a/docs/explanation/privacy-model.md
+++ b/docs/explanation/privacy-model.md
@@ -49,7 +49,7 @@ Every "memory MCP" stores your raw text in a database. Distill doesn't. The LLM 
 | Does Anthropic see my raw input? | No. It goes to the distiller: Ollama (local) or Gemini (Google). |
 | Can my team read what I typed? | No. Only the distilled fact is stored. |
 | Can my manager see who wrote what? | Only if you opt in (`AUTH_ENABLED=true`). Anonymous by default. |
-| Where is my raw text? | `~/.distill/private/` on your machine. Delete anytime. |
+| Where is my raw text? | `~/.team-memory/private/` on your machine. Delete anytime. |
 | What if distillation leaks a name? | The scanner checks all distilled output for PII and secrets before saving. |
 
 ## The scanner: secrets and PII

--- a/docs/how-to/installation.md
+++ b/docs/how-to/installation.md
@@ -36,7 +36,7 @@ ollama pull nomic-embed-text   # embeddings (768-dim vectors for search)
 You can override these with environment variables:
 
 ```bash
-export DISTILL_MODEL=gemma3:4b          # any Ollama model
+export LLM_MODEL=gemma3:4b              # any Ollama model
 export EMBEDDING_MODEL=nomic-embed-text # must produce 768-dim vectors
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,92 @@
+---
+title: CLI Commands
+---
+
+# CLI Commands
+
+Distill provides CLI commands for administration tasks. All commands are run via the `distill_mcp` module:
+
+```bash
+python -m distill_mcp <command> [options]
+```
+
+Running without a command starts the MCP server (the default mode).
+
+## check-hardware
+
+Detect GPU and hardware capabilities for Ollama performance tuning.
+
+```bash
+python -m distill_mcp check-hardware
+```
+
+Outputs a report of detected GPUs, VRAM, CPU cores, and RAM. Useful for verifying that Ollama will use GPU acceleration.
+
+## reembed
+
+Rebuild all vector embeddings when switching embedding models. Backs up the existing LanceDB vectors before rebuilding.
+
+```bash
+python -m distill_mcp reembed
+```
+
+Use this when:
+
+- You've changed `EMBEDDING_PROVIDER` or `EMBEDDING_MODEL`
+- The server fails to start with an "Embedding dimension mismatch" error
+- You want to upgrade to a better embedding model
+
+The command:
+
+1. Backs up `~/.team-memory/lance/` to `lance.bak.<dim>/`
+2. Drops the existing vectors table
+3. Re-embeds every memory with the current embedding model
+4. Updates the stored embedding metadata
+
+## seed
+
+Populate the knowledge base from git history. Requires the distill MCP server to be running (it POSTs to the ingest endpoint).
+
+```bash
+python -m distill_mcp seed [--since <date>] [--port <port>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--since <date>` | Only process commits after this date (passed to `git log --since`) |
+| `--port <port>` | Ingest endpoint port (default: from `INGEST_PORT` setting, usually `21746`) |
+
+The command reads `git log`, filters out trivial commits (chore, style, ci, merge, fixup, squash), and POSTs each remaining commit to the `/observe` endpoint for distillation by the background worker.
+
+Must be run inside a git repository. The repository name is derived from the `origin` remote URL.
+
+See the [Seed from Git](../how-to/seed-from-git.md) how-to guide for a walkthrough.
+
+## export
+
+Export memories to JSON or CSV.
+
+```bash
+python -m distill_mcp export [--format json|csv] [--output <file>] [--repo <name>] [--type <type>] [--after <date>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--format json\|csv` | Output format (default: `json`) |
+| `--output <file>` | Write to file instead of stdout |
+| `--repo <name>` | Filter by repository name |
+| `--type <type>` | Filter by memory type (`decision`, `context`, `failure`, `pattern`, `dependency`) |
+| `--after <date>` | Only export memories created after this ISO 8601 date |
+
+Examples:
+
+```bash
+# Export all memories as JSON to stdout
+python -m distill_mcp export
+
+# Export decisions from a specific repo to a file
+python -m distill_mcp export --format csv --repo myapp --type decision --output decisions.csv
+
+# Export everything since March 2026
+python -m distill_mcp export --after 2026-03-01 --output recent.json
+```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,7 +20,7 @@ All settings are controlled via environment variables (or a `.env` file).
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `EMBEDDING_PROVIDER` | `ollama` | Provider: `ollama`, `gemini`, `vertex`, `bedrock`, `azure` |
-| `EMBEDDING_MODEL` | *(per provider)* | Embedding model name. Defaults: ollama=`nomic-embed-text`, gemini=`text-embedding-004`, vertex=`text-embedding-005`, bedrock=`amazon.titan-embed-text-v2:0`, azure=`text-embedding-3-small` |
+| `EMBEDDING_MODEL` | *(per provider)* | Embedding model name. Defaults: ollama=`nomic-embed-text`, gemini=`gemini-embedding-001`, vertex=`text-embedding-005`, bedrock=`amazon.titan-embed-text-v2:0`, azure=`text-embedding-3-small` |
 
 All embeddings must produce **768-dimensional** vectors.
 
@@ -79,7 +79,7 @@ Uses the default AWS credential chain (environment variables, `~/.aws/credential
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DISTILL_INGEST_PORT` | `21746` | Port for the local HTTP `/observe` endpoint |
+| `INGEST_PORT` | `21746` | Port for the local HTTP `/observe` endpoint |
 
 ## Privacy & processing
 
@@ -88,6 +88,7 @@ Uses the default AWS credential chain (environment variables, `~/.aws/credential
 | `DISTILL_ENABLED` | `true` | Enable LLM distillation (disable for testing) |
 | `DEFAULT_AUTHOR` | `unknown` | Default author attribution |
 | `AUTH_ENABLED` | `false` | Enable git-based identity + PostgreSQL RLS |
+| `RETENTION_DAYS` | `90` | Hard-delete soft-deleted memories after this many days (0 to disable) |
 
 ## Search tuning
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -4,7 +4,7 @@ title: MCP Tools
 
 # MCP Tools Reference
 
-Distill exposes 7 tools via the MCP protocol. Claude Code calls these automatically based on conversation context.
+Distill exposes 8 tools via the MCP protocol. Claude Code calls these automatically based on conversation context.
 
 Memories are captured automatically via the [auto-observe pipeline](../explanation/how-memory-works.md) — there is no explicit "remember" tool. The tools below are for **reading, searching, and managing** existing memories.
 
@@ -18,8 +18,10 @@ Hybrid search combining full-text (FTS5/tsvector) and vector similarity (LanceDB
 | `top_k` | int | no | Max results (default: 5, max: 100) |
 | `repo` | string | no | Filter by repository |
 | `agent_id` | string | no | Filter by agent |
+| `after` | string | no | Only return memories created after this date (ISO 8601, e.g. `"2025-01-01"`) |
+| `before` | string | no | Only return memories created before this date (ISO 8601, e.g. `"2025-06-01"`) |
 
-**Returns:** Compact index (~30 tokens/result) with `id`, `type`, `snippet`, `score`, `est_tokens`, `level`. Use `get_memories` to fetch full content for relevant results.
+**Returns:** Compact index (~30 tokens/result) with `id`, `type`, `level`, `snippet`, `repos`, `score`, `created_at`, `est_tokens`, `agent_id`. Use `get_memories` to fetch full content for relevant results.
 
 ## get_memories
 
@@ -81,3 +83,13 @@ Soft-delete a memory. It will no longer appear in search results.
 |-----------|------|----------|-------------|
 | `id` | string | yes | Memory ID to delete |
 | `agent_id` | string | no | If provided, only deletes if the memory belongs to this agent |
+
+## get_lineage
+
+Trace the supersedes chain for a memory in both directions. Returns the full history: predecessors (what this memory replaced) and successors (what replaced this memory), ordered oldest to newest. Useful for understanding how a decision evolved over time.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | yes | Memory ID to trace |
+
+**Returns:** List of memory dicts in the supersedes chain, ordered oldest to newest.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -47,23 +47,33 @@ Or if running from source:
 claude mcp add distill -- uv run python -m distill_mcp
 ```
 
-## Step 4: Store your first memory
+## Step 4: Set up the auto-observe hook
 
-Open Claude Code and say:
+Distill captures knowledge automatically from your Claude Code tool calls. Add the PostToolUse hook to your Claude Code settings:
+
+```bash
+claude hooks add PostToolUse \
+  'curl -s -X POST http://127.0.0.1:21746/observe \
+    -H "Content-Type: application/json" \
+    -d @- <<< "$CLAUDE_HOOK_PAYLOAD" &'
+```
+
+Now every tool call (Read, Bash, Edit, etc.) is automatically captured in the background — zero latency impact on Claude.
+
+## Step 5: Use Claude Code normally
+
+There's nothing special to do. Work as you normally would:
 
 ```
-You:    "Remember that we chose gRPC over REST for inter-service
-         communication because of streaming support and type safety."
+You:    "Let's use gRPC instead of REST for inter-service communication
+         because of streaming support and type safety."
+
+Claude: [edits code, runs tests, etc.]
 ```
 
-Claude will:
+Behind the scenes, Distill's background worker distills each tool call into anonymous, factual knowledge and stores it in the team database.
 
-1. Send the raw text to your **local** Ollama for distillation
-2. Show you the distilled preview (e.g., *"gRPC was chosen over REST for inter-service communication due to streaming support and type safety."*)
-3. Wait for your approval
-4. Store the approved fact in the team database
-
-## Step 5: Search your memories
+## Step 6: Search your memories
 
 ```
 You:    "How do our services communicate?"
@@ -77,7 +87,7 @@ Claude: [searches team memory]
 
 - How to install Distill and its Ollama dependencies
 - How to register the MCP server with Claude Code
-- The two-phase remember flow: distill → preview → confirm
+- How to set up the auto-observe hook for automatic knowledge capture
 - How search retrieves stored team knowledge
 
 ## Next steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Gemini Backend: how-to/gemini-backend.md
   - Reference:
     - MCP Tools: reference/tools.md
+    - CLI Commands: reference/cli.md
     - Configuration: reference/configuration.md
   - Explanation:
     - How Memory Works: explanation/how-memory-works.md


### PR DESCRIPTION
## Summary
- Sync documentation with v0.4.0 code: add `get_lineage` tool, temporal search (`after`/`before`), `RETENTION_DAYS`, and CLI reference page
- Fix stale content: wrong env var names, outdated remember/confirm tutorial, incorrect paths and defaults
- Add new `reference/cli.md` documenting `check-hardware`, `reembed`, `seed`, `export` commands

## Changes
- **reference/tools.md** — added `get_lineage`, `after`/`before` params, updated tool count 7→8
- **reference/cli.md** — new page for CLI commands
- **reference/configuration.md** — added `RETENTION_DAYS`, fixed `DISTILL_INGEST_PORT`→`INGEST_PORT`, fixed gemini embedding default
- **explanation/architecture.md** — 8 tools, added bedrock/azure/identity adapters, dedup.py, hardware.py
- **explanation/how-memory-works.md** — added lineage tracking, temporal search, retention purge sections
- **explanation/privacy-model.md** — fixed private store path
- **tutorials/getting-started.md** — replaced outdated remember/confirm with auto-observe hook setup
- **how-to/installation.md** — fixed `DISTILL_MODEL`→`LLM_MODEL`
- **mkdocs.yml** — added CLI Commands to nav

## Test plan
- [x] `mkdocs build --strict` passes with no errors
- [x] All pytest tests pass (257 passed)
- [ ] Visual review of rendered site

🤖 Generated with [Claude Code](https://claude.com/claude-code)